### PR TITLE
[codex] Implement OTA update workflow and firmware hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,12 @@ Build the first vertical slice:
 - web service publishes retained config JSON
 - firmware applies setpoint/hysteresis from MQTT config
 
-After that, add OTA:
+OTA is now wired in the repo:
 
-- web service hosts firmware manifest and `.bin`
-- MQTT command triggers update checks
-- ESP32 downloads and applies firmware over Wi-Fi
+- web service exposes a firmware manifest and serves the mounted firmware `.bin`
+- MQTT commands trigger update checks or update start
+- ESP32 downloads and applies firmware over Wi-Fi using OTA partitions
+- HTTPS OTA requires a configured certificate fingerprint; plain HTTP must be explicitly allowed
 
 ## Recovery AP defaults
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -106,6 +106,8 @@ The ESP32 firmware should be split into small modules with clear boundaries.
 - check firmware manifest over HTTP/HTTPS
 - download new firmware image over Wi-Fi
 - validate version/channel before install
+- require a configured TLS certificate fingerprint for HTTPS
+- allow plain HTTP only when explicitly enabled in `system_config`
 - perform OTA update and reboot
 - report progress and result through state/event topics
 
@@ -149,8 +151,8 @@ Planned services:
 - `mqtt`: Eclipse Mosquitto broker
 - `web`: FastAPI application
 - `db`: PostgreSQL database
-- `firmware-files`: firmware manifest and binary hosting, either inside `web` or
-  as static files behind a reverse proxy
+- `firmware-files`: firmware manifest and binary hosting, currently mounted into
+  `web` from the local PlatformIO build output
 
 Later optional services:
 
@@ -274,6 +276,16 @@ Recommended OTA flow:
 3. ESP32 downloads firmware directly over HTTP/HTTPS.
 4. ESP32 installs update into OTA partition, reboots, and reports result.
 
+Current implementation details:
+
+- firmware uses a dedicated OTA partition table via `firmware/partitions_ota.csv`
+- web serves manifest JSON from `/firmware/manifest/<channel>.json`
+- web serves binaries from `/firmware/files/<filename>`
+- Docker Compose mounts `firmware/.pio/build/esp32dev` into the web container as
+  the firmware file source
+- scheduled OTA checks can run locally from saved config and do not require MQTT
+  to be connected
+
 Why not distribute firmware over MQTT:
 
 - firmware binaries are too large for MQTT to be the primary transport
@@ -284,7 +296,8 @@ Recommended control split:
 
 - MQTT triggers `check_update` or `start_update`
 - HTTP/HTTPS transfers the manifest and `.bin`
-- state/event topics expose version, in-progress status, and errors
+- state/event topics expose version, OTA availability, reboot-pending state, and
+  result/error messages
 
 Suggested firmware manifest fields:
 
@@ -294,6 +307,11 @@ Suggested firmware manifest fields:
 - `min_schema_version`
 - `sha256`
 - `download_url`
+
+Current OTA policy:
+
+- HTTPS OTA requires `ota.ca_cert_fingerprint`
+- HTTP OTA is blocked unless `ota.allow_http` is `true`
 
 ## Output backend model
 

--- a/docs/mqtt-contract.md
+++ b/docs/mqtt-contract.md
@@ -125,7 +125,7 @@ Payload example:
 ```json
 {
   "device_id": "fermenter-01",
-  "ts": "2026-03-29T14:00:00Z",
+  "ui": "headless",
   "mode": "thermostat",
   "setpoint_c": 19.0,
   "hysteresis_c": 0.3,
@@ -133,12 +133,35 @@ Payload example:
   "heating_delay_s": 120,
   "fw_version": "0.1.0",
   "ota_status": "idle",
-  "heating": false,
-  "cooling": true,
-  "active_config_version": 4,
-  "fault": null
+  "ota_channel": "stable",
+  "ota_available": false,
+  "ota_progress_pct": 0,
+  "ota_reboot_pending": false,
+  "heating": "off",
+  "cooling": "on",
+  "heating_desc": "gpio 25 off",
+  "cooling_desc": "kasa 192.168.1.88 on",
+  "controller_state": "cooling",
+  "controller_reason": "primary_above_setpoint",
+  "automatic_control_active": true,
+  "secondary_sensor_enabled": false,
+  "control_sensor": "primary",
+  "beer_probe_present": true,
+  "beer_probe_valid": true,
+  "beer_probe_rom": "28ff112233445566",
+  "chamber_probe_present": true,
+  "chamber_probe_valid": true,
+  "chamber_probe_rom": "28ffaa9988776655"
 }
 ```
+
+Additional OTA fields:
+
+- `ota_target_version` is included when a manifest check found a newer image
+- `ota_message` is included when firmware has a useful human-readable OTA result
+- `ota_progress_pct` is currently coarse-grained; the current firmware reports `100`
+  when the new image is staged and reboot is pending, otherwise `0`
+- `heating` and `cooling` in `state` are string enums: `on`, `off`, or `unknown`
 
 ### `history/raw`
 
@@ -242,6 +265,15 @@ Payload example:
 }
 ```
 
+Current OTA-specific commands accepted by firmware:
+
+- `check_update`
+- `start_update`
+
+For OTA commands, the requested channel may be provided either as
+`args.channel` or as a top-level `channel`. Firmware prefers `args.channel`
+when both are present.
+
 ## System config recommendation
 
 Do not make MQTT the only path for:
@@ -293,19 +325,41 @@ Recommended model:
 - ESP32 fetches a firmware manifest over HTTP/HTTPS
 - ESP32 downloads the `.bin` over HTTP/HTTPS
 - ESP32 reports progress and final status on `state` and `event`
+- scheduled checks may also run locally from saved OTA config
+- HTTPS OTA requires `ca_cert_fingerprint`
+- plain HTTP OTA requires `allow_http = true`
 
 Example event payload:
 
 ```json
 {
   "device_id": "fermenter-01",
-  "ts": "2026-03-29T14:06:00Z",
+  "ts": 1743343560,
   "event": "ota_update_completed",
   "fw_version": "0.2.0",
+  "ota_status": "rebooting",
+  "target_version": "0.2.0",
   "result": "ok",
   "message": null
 }
 ```
+
+OTA-related events currently emitted by firmware:
+
+- `ota_check_completed`
+- `ota_update_completed`
+
+For `ota_check_completed`, `result` is one of:
+
+- `update_available`
+- `no_update`
+- `error`
+
+For `ota_update_completed`, `result` is one of:
+
+- `ok`
+- `no_update`
+- `error`
 
 ## Contract rules
 

--- a/docs/windows-usb-and-ota.md
+++ b/docs/windows-usb-and-ota.md
@@ -5,8 +5,8 @@ This document explains:
 1. how to flash the ESP32 from a Windows computer over USB-C
 2. how OTA updates are intended to work in this project
 
-The project currently has a firmware skeleton and OTA design, but OTA is not yet
-fully implemented in code. The USB flashing steps are the primary path right now.
+The repo now contains an OTA implementation path in firmware and web hosting,
+but first install on a blank ESP32 is still done over USB-C.
 
 ## Current assumptions
 
@@ -143,6 +143,11 @@ For ESP32 OTA, the firmware layout must support at least:
 
 Espressif documents this explicitly in the OTA docs.
 
+Current repo implementation:
+
+- `firmware/platformio.ini` uses `partitions_ota.csv`
+- the partition table defines `ota_0`, `ota_1`, and `otadata`
+
 Official docs:
 
 - ESP-IDF OTA overview: https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/ota.html
@@ -160,16 +165,25 @@ Official docs:
 8. ESP32 reboots into the new image.
 9. ESP32 reports success or rollback/failure via MQTT state/event topics.
 
+Current repo wiring:
+
+- manifest endpoint: `/firmware/manifest/<channel>.json`
+- binary endpoint: `/firmware/files/<filename>`
+- Docker Compose mounts `firmware/.pio/build/esp32dev` into the web container at
+  `/app/firmware-files`
+- the default hosted filename is `firmware.bin`
+- scheduled OTA checks can run locally from saved config
+
 ### Why OTA should not send the binary over MQTT
 
 - firmware binaries are large compared to normal MQTT messages
 - HTTP/HTTPS is better suited to downloads, retries, and hosting
 - it is easier to inspect, cache, and secure firmware artifacts
 
-### Planned configuration for OTA
+### OTA configuration in the repo
 
-The current `system_config` schema already reserves an `ota` block with fields
-such as:
+The current `system_config` schema and firmware config store support an `ota`
+block with fields such as:
 
 - `enabled`
 - `channel`
@@ -179,13 +193,20 @@ such as:
 - `ca_cert_fingerprint`
 - `allow_http`
 
+Current behavior:
+
+- HTTPS OTA requires `ca_cert_fingerprint`
+- HTTP OTA is rejected unless `allow_http` is enabled
+- provisioning/recovery UI exposes the OTA fields and persists them locally
+
 See:
 
 - [system-config.schema.json](C:\Users\ola\git\brewesp\docs\schemas\system-config.schema.json)
 
-### Planned MQTT commands for OTA
+### MQTT commands and state for OTA
 
-The current MQTT contract reserves OTA-related commands such as:
+The current MQTT contract and firmware command handler support OTA commands such
+as:
 
 - `check_update`
 - `start_update`
@@ -194,6 +215,17 @@ and state fields such as:
 
 - `fw_version`
 - `ota_status`
+- `ota_channel`
+- `ota_available`
+- `ota_progress_pct`
+- `ota_target_version`
+- `ota_message`
+- `ota_reboot_pending`
+
+and OTA-related events such as:
+
+- `ota_check_completed`
+- `ota_update_completed`
 
 See:
 
@@ -205,18 +237,20 @@ Use this sequence:
 
 1. Get USB flashing stable on Windows.
 2. Verify serial logs and Wi-Fi provisioning.
-3. Add custom partition table for OTA.
-4. Implement OTA manager in firmware.
-5. Host firmware manifest and binaries in the web service.
-6. Add MQTT command path for OTA start/check.
-7. Test upgrade and rollback on a spare firmware image before relying on it.
+3. Build the firmware so `firmware/.pio/build/esp32dev/firmware.bin` exists.
+4. Bring up the web service so it can host the mounted firmware artifact.
+5. Set OTA config on the device, including `manifest_url` and, for HTTPS,
+   `ca_cert_fingerprint`.
+6. Trigger `check_update` or `start_update` over MQTT.
+7. Test upgrade and failure handling on a spare device before relying on it.
 
 ## Current project status
 
 Today:
 
-- USB flashing workflow is the way to install firmware
-- OTA is designed in the docs but not completed in firmware yet
+- USB flashing workflow is still the first-install path
+- OTA is implemented in firmware and web hosting in the repo
+- real-device OTA validation is still recommended before relying on it in production
 
 That means the first time you load new firmware, you should expect to do it over
 USB-C from Windows.

--- a/firmware/include/App.h
+++ b/firmware/include/App.h
@@ -6,6 +6,7 @@
 #include "config/SystemConfig.h"
 #include "network/MqttManager.h"
 #include "network/ProvisioningManager.h"
+#include "ota/OtaManager.h"
 #include "output/KasaDiscovery.h"
 #include "output/OutputManager.h"
 #include "sensor/SensorManager.h"
@@ -25,6 +26,9 @@ private:
     void handleSystemConfig(const SystemConfig& updatedConfig);
     void handleFermentationConfig(const FermentationConfig& updatedConfig);
     void handleOutputCommand(const String& target, OutputState state);
+    void handleOtaCommand(const String& command, const String& channel);
+    void processPendingOtaCommand();
+    bool isOtaLockoutActive() const;
     void runKasaDiscovery();
     SystemConfig buildDefaultConfig() const;
     ControllerEngine::Inputs buildControllerInputs() const;
@@ -35,11 +39,16 @@ private:
     ConfigStore configStore_;
     ProvisioningManager provisioning_;
     MqttManager mqtt_;
+    OtaManager ota_;
     KasaDiscovery kasaDiscovery_;
     OutputManager outputs_;
     SensorManager sensors_;
     LocalUiManager localUi_;
     uint32_t lastHeartbeatLogMs_ = 0;
     uint32_t wifiConnectStartedMs_ = 0;
+    uint32_t otaRestartAtMs_ = 0;
     bool provisioningMode_ = false;
+    bool otaShutdownPending_ = false;
+    String pendingOtaCommand_;
+    String pendingOtaChannel_;
 };

--- a/firmware/include/config/FirmwareVersion.h
+++ b/firmware/include/config/FirmwareVersion.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#ifndef BREWESP_FIRMWARE_VERSION
+#define BREWESP_FIRMWARE_VERSION "0.1.0-dev"
+#endif
+
+namespace FirmwareVersion {
+static constexpr const char* kCurrent = BREWESP_FIRMWARE_VERSION;
+}

--- a/firmware/include/config/SystemConfig.h
+++ b/firmware/include/config/SystemConfig.h
@@ -82,6 +82,16 @@ struct SensorBusConfig {
     String chamberProbeRom;
 };
 
+struct OtaConfig {
+    bool enabled = true;
+    String channel = "stable";
+    String checkStrategy = "manual";
+    uint32_t checkIntervalSeconds = 86400;
+    String manifestUrl;
+    String caCertFingerprint;
+    bool allowHttp = false;
+};
+
 struct SystemConfig {
     String deviceId = "brewesp-dev";
     WifiConfig wifi;
@@ -93,4 +103,5 @@ struct SystemConfig {
     ButtonsConfig buttons;
     OutputConfig heatingOutput;
     OutputConfig coolingOutput;
+    OtaConfig ota;
 };

--- a/firmware/include/network/MqttManager.h
+++ b/firmware/include/network/MqttManager.h
@@ -37,12 +37,20 @@ public:
         bool chamberProbeValid = false;
         String chamberProbeRom;
         String profileId;
+        String otaStatus = "idle";
+        String otaMessage;
+        String otaChannel = "stable";
+        String otaTargetVersion;
+        bool otaUpdateAvailable = false;
+        uint8_t otaProgressPercent = 0;
+        bool otaRebootPending = false;
     };
 
     using SystemConfigHandler = std::function<void(const SystemConfig&)>;
     using FermentationConfigHandler = std::function<void(const FermentationConfig&)>;
     using OutputCommandHandler = std::function<void(const String&, OutputState)>;
     using DiscoveryRequestHandler = std::function<void()>;
+    using OtaCommandHandler = std::function<void(const String&, const String&)>;
 
     bool begin(const SystemConfig& config);
     void update(
@@ -55,6 +63,7 @@ public:
     void setFermentationConfigHandler(FermentationConfigHandler handler);
     void setOutputCommandHandler(OutputCommandHandler handler);
     void setDiscoveryRequestHandler(DiscoveryRequestHandler handler);
+    void setOtaCommandHandler(OtaCommandHandler handler);
     void publishState(
         const SystemConfig& config,
         const OutputManager& outputs,
@@ -66,6 +75,12 @@ public:
         const char* result,
         const char* message);
     void publishKasaDiscovery(const SystemConfig& config, const String& devicePayload);
+    void publishEvent(
+        const SystemConfig& config,
+        const char* eventName,
+        const char* result,
+        const char* message,
+        const TelemetrySnapshot& telemetry);
 
 private:
     bool connectIfNeeded(
@@ -98,4 +113,5 @@ private:
     FermentationConfigHandler fermentationConfigHandler_;
     OutputCommandHandler outputCommandHandler_;
     DiscoveryRequestHandler discoveryRequestHandler_;
+    OtaCommandHandler otaCommandHandler_;
 };

--- a/firmware/include/ota/OtaManager.h
+++ b/firmware/include/ota/OtaManager.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <Arduino.h>
+
+#include <memory>
+
+#include "config/SystemConfig.h"
+
+class HTTPClient;
+class WiFiClient;
+
+class OtaManager {
+public:
+    struct Manifest {
+        bool valid = false;
+        String version;
+        String channel;
+        String publishedAt;
+        uint32_t minSchemaVersion = 0;
+        String sha256;
+        String downloadUrl;
+    };
+
+    struct CheckResult {
+        bool success = false;
+        bool updateAvailable = false;
+        String message;
+        Manifest manifest;
+    };
+
+    struct InstallResult {
+        bool success = false;
+        String message;
+        Manifest manifest;
+    };
+
+    void begin(const SystemConfig& config);
+    bool shouldRunScheduledCheck(const SystemConfig& config, uint32_t nowMs) const;
+    CheckResult checkForUpdate(const SystemConfig& config, const String& requestedChannel = "");
+    InstallResult startUpdate(const SystemConfig& config, const String& requestedChannel = "");
+    const String& status() const;
+    const String& message() const;
+    const String& targetVersion() const;
+
+private:
+    struct ParsedUrl {
+        String scheme;
+        String host;
+        uint16_t port = 0;
+        String path = "/";
+    };
+
+    bool fetchManifest(const SystemConfig& config, const String& requestedChannel, Manifest& manifest, String& error);
+    bool downloadAndInstall(const SystemConfig& config, const Manifest& manifest, String& error);
+    bool httpGet(const String& url, const OtaConfig& config, String& body, String& error);
+    bool beginHttpRequest(
+        const String& url,
+        const OtaConfig& config,
+        HTTPClient& http,
+        std::unique_ptr<WiFiClient>& client,
+        ParsedUrl& parsedUrl,
+        String& error);
+    bool parseManifest(const String& body, Manifest& manifest, String& error) const;
+    bool parseUrl(const String& url, ParsedUrl& parsedUrl, String& error) const;
+    String effectiveChannel(const SystemConfig& config, const String& requestedChannel) const;
+    String normalizeCompactHex(const String& value) const;
+    int compareVersions(const String& lhs, const String& rhs) const;
+    void setStatus(const String& status, const String& message = "", const String& targetVersion = "");
+
+    uint32_t lastCheckStartedMs_ = 0;
+    String status_ = "idle";
+    String message_;
+    String targetVersion_;
+};

--- a/firmware/partitions_ota.csv
+++ b/firmware/partitions_ota.csv
@@ -1,0 +1,6 @@
+# Name,   Type, SubType, Offset,   Size,     Flags
+nvs,      data, nvs,     0x9000,   0x5000,
+otadata,  data, ota,     0xE000,   0x2000,
+app0,     app,  ota_0,   0x10000,  0x180000,
+app1,     app,  ota_1,   0x190000, 0x180000,
+spiffs,   data, spiffs,  0x310000, 0x0F0000,

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -6,6 +6,7 @@ platform = espressif32
 board = esp32dev
 framework = arduino
 monitor_speed = 115200
+board_build.partitions = partitions_ota.csv
 lib_deps =
   knolleary/PubSubClient @ ^2.8
   bblanchon/ArduinoJson @ ^6.21.5

--- a/firmware/src/App.cpp
+++ b/firmware/src/App.cpp
@@ -23,11 +23,14 @@ void App::begin() {
     mqtt_.setOutputCommandHandler(
         [this](const String& target, OutputState state) { handleOutputCommand(target, state); });
     mqtt_.setDiscoveryRequestHandler([this]() { runKasaDiscovery(); });
+    mqtt_.setOtaCommandHandler(
+        [this](const String& command, const String& channel) { handleOtaCommand(command, channel); });
 
     localUi_.begin(config_);
     outputs_.begin(config_);
     sensors_.begin(config_);
     controller_.reset();
+    ota_.begin(config_);
 
     if (config_.wifi.ssid.isEmpty()) {
         startProvisioningMode("missing Wi-Fi config");
@@ -52,10 +55,34 @@ void App::update() {
     localUi_.update();
     outputs_.update();
     sensors_.update(config_);
-    if (controller_.update(fermentationConfig_, buildControllerInputs(), outputs_)) {
+    if (isOtaLockoutActive()) {
+        outputs_.setHeating(OutputState::Off);
+        outputs_.setCooling(OutputState::Off);
+        outputs_.refreshStates();
+    } else if (controller_.update(fermentationConfig_, buildControllerInputs(), outputs_)) {
         mqtt_.publishState(config_, outputs_, localUi_, buildTelemetrySnapshot());
     }
     mqtt_.update(config_, outputs_, localUi_, buildTelemetrySnapshot());
+    processPendingOtaCommand();
+    if (ota_.shouldRunScheduledCheck(config_, millis())) {
+        OtaManager::CheckResult check = ota_.checkForUpdate(config_);
+        if (mqtt_.isConnected()) {
+            mqtt_.publishState(config_, outputs_, localUi_, buildTelemetrySnapshot());
+            mqtt_.publishEvent(
+                config_,
+                "ota_check_completed",
+                check.success ? (check.updateAvailable ? "update_available" : "no_update") : "error",
+                check.message.c_str(),
+                buildTelemetrySnapshot());
+        }
+    }
+    if (otaRestartAtMs_ != 0 && millis() >= otaRestartAtMs_) {
+        Serial.println("[ota] rebooting into staged firmware");
+        delay(250);
+        otaRestartAtMs_ = 0;
+        otaShutdownPending_ = false;
+        ESP.restart();
+    }
 
     const uint32_t now = millis();
     if (now - lastHeartbeatLogMs_ < kHeartbeatLogIntervalMs) {
@@ -85,9 +112,11 @@ void App::handleSystemConfig(const SystemConfig& updatedConfig) {
     config_.heatingOutput = updatedConfig.heatingOutput;
     config_.coolingOutput = updatedConfig.coolingOutput;
     config_.heartbeat = updatedConfig.heartbeat;
+    config_.ota = updatedConfig.ota;
     configStore_.save(config_);
     sensors_.begin(config_);
     outputs_.applyConfig(config_);
+    ota_.begin(config_);
     mqtt_.publishState(config_, outputs_, localUi_, buildTelemetrySnapshot());
     Serial.println("[app] applied system_config from MQTT");
 }
@@ -120,6 +149,14 @@ void App::handleOutputCommand(const String& target, OutputState state) {
         return;
     }
 
+    if (isOtaLockoutActive()) {
+        Serial.printf(
+            "[app] ignoring output command during OTA reboot pending target=%s state=%s\r\n",
+            target.c_str(),
+            state == OutputState::On ? "on" : "off");
+        return;
+    }
+
     Serial.printf(
         "[app] output command target=%s state=%s\r\n",
         target.c_str(),
@@ -143,6 +180,69 @@ void App::handleOutputCommand(const String& target, OutputState state) {
     if (changed) {
         mqtt_.publishState(config_, outputs_, localUi_, buildTelemetrySnapshot());
     }
+}
+
+void App::handleOtaCommand(const String& command, const String& channel) {
+    Serial.printf("[app] ota command=%s channel=%s\r\n", command.c_str(), channel.c_str());
+    pendingOtaCommand_ = command;
+    pendingOtaChannel_ = channel;
+}
+
+void App::processPendingOtaCommand() {
+    if (pendingOtaCommand_.isEmpty()) {
+        return;
+    }
+
+    const String command = pendingOtaCommand_;
+    const String channel = pendingOtaChannel_;
+    pendingOtaCommand_ = "";
+    pendingOtaChannel_ = "";
+
+    if (command == "check_update") {
+        const OtaManager::CheckResult check = ota_.checkForUpdate(config_, channel);
+        if (mqtt_.isConnected()) {
+            mqtt_.publishState(config_, outputs_, localUi_, buildTelemetrySnapshot());
+            mqtt_.publishEvent(
+                config_,
+                "ota_check_completed",
+                check.success ? (check.updateAvailable ? "update_available" : "no_update") : "error",
+                check.message.c_str(),
+                buildTelemetrySnapshot());
+        }
+        return;
+    }
+
+    if (command != "start_update") {
+        return;
+    }
+
+    const bool heatingChanged = outputs_.setHeating(OutputState::Off);
+    const bool coolingChanged = outputs_.setCooling(OutputState::Off);
+    outputs_.refreshStates();
+    if (heatingChanged || coolingChanged) {
+        mqtt_.publishState(config_, outputs_, localUi_, buildTelemetrySnapshot());
+    }
+
+    const OtaManager::InstallResult install = ota_.startUpdate(config_, channel);
+    if (mqtt_.isConnected()) {
+        mqtt_.publishState(config_, outputs_, localUi_, buildTelemetrySnapshot());
+        mqtt_.publishEvent(
+            config_,
+            "ota_update_completed",
+            install.success ? (ota_.status() == "rebooting" ? "ok" : "no_update") : "error",
+            install.message.c_str(),
+            buildTelemetrySnapshot());
+    }
+    if (install.success && ota_.status() == "rebooting") {
+        otaShutdownPending_ = true;
+        otaRestartAtMs_ = millis() + 1500UL;
+    } else {
+        otaShutdownPending_ = false;
+    }
+}
+
+bool App::isOtaLockoutActive() const {
+    return otaShutdownPending_ || otaRestartAtMs_ != 0;
 }
 
 MqttManager::TelemetrySnapshot App::buildTelemetrySnapshot() const {
@@ -179,6 +279,13 @@ MqttManager::TelemetrySnapshot App::buildTelemetrySnapshot() const {
     if (chamberProbe.present) {
         telemetry.chamberProbeRom = sensors_.chamberProbeRom();
     }
+    telemetry.otaStatus = ota_.status();
+    telemetry.otaMessage = ota_.message();
+    telemetry.otaChannel = config_.ota.channel;
+    telemetry.otaTargetVersion = ota_.targetVersion();
+    telemetry.otaUpdateAvailable = ota_.status() == "update_available";
+    telemetry.otaProgressPercent = ota_.status() == "rebooting" ? 100 : 0;
+    telemetry.otaRebootPending = isOtaLockoutActive();
     return telemetry;
 }
 
@@ -293,6 +400,14 @@ SystemConfig App::buildDefaultConfig() const {
     config.coolingOutput.port = 9999;
     config.coolingOutput.alias = "cooling-plug";
     config.coolingOutput.pollIntervalSeconds = 30;
+
+    config.ota.enabled = true;
+    config.ota.channel = "stable";
+    config.ota.checkStrategy = "manual";
+    config.ota.checkIntervalSeconds = 86400;
+    config.ota.manifestUrl = "";
+    config.ota.caCertFingerprint = "";
+    config.ota.allowHttp = false;
 
     return config;
 }

--- a/firmware/src/config/ConfigStore.cpp
+++ b/firmware/src/config/ConfigStore.cpp
@@ -100,6 +100,15 @@ bool ConfigStore::load(SystemConfig& config) {
     config.coolingOutput.host = prefs.getString("cool_host", config.coolingOutput.host);
     config.coolingOutput.port = prefs.getUInt("cool_port", config.coolingOutput.port);
     config.coolingOutput.alias = prefs.getString("cool_alias", config.coolingOutput.alias);
+    config.ota.enabled = prefs.getBool("ota_en", config.ota.enabled);
+    config.ota.channel = prefs.getString("ota_chan", config.ota.channel);
+    config.ota.checkStrategy = prefs.getString("ota_chk", config.ota.checkStrategy);
+    config.ota.checkIntervalSeconds =
+        prefs.getUInt("ota_int", config.ota.checkIntervalSeconds);
+    config.ota.manifestUrl = prefs.getString("ota_url", config.ota.manifestUrl);
+    config.ota.caCertFingerprint =
+        prefs.getString("ota_fp", config.ota.caCertFingerprint);
+    config.ota.allowHttp = prefs.getBool("ota_http", config.ota.allowHttp);
 
     prefs.end();
     return !config.wifi.ssid.isEmpty();
@@ -158,6 +167,13 @@ bool ConfigStore::save(const SystemConfig& config) {
     prefs.putString("cool_host", config.coolingOutput.host);
     prefs.putUInt("cool_port", config.coolingOutput.port);
     prefs.putString("cool_alias", config.coolingOutput.alias);
+    prefs.putBool("ota_en", config.ota.enabled);
+    prefs.putString("ota_chan", config.ota.channel);
+    prefs.putString("ota_chk", config.ota.checkStrategy);
+    prefs.putUInt("ota_int", config.ota.checkIntervalSeconds);
+    prefs.putString("ota_url", config.ota.manifestUrl);
+    prefs.putString("ota_fp", config.ota.caCertFingerprint);
+    prefs.putBool("ota_http", config.ota.allowHttp);
 
     prefs.end();
     return true;

--- a/firmware/src/network/MqttManager.cpp
+++ b/firmware/src/network/MqttManager.cpp
@@ -5,11 +5,11 @@
 #include <ArduinoJson.h>
 #include <WiFi.h>
 
+#include "config/FirmwareVersion.h"
 #include "output/OutputManager.h"
 #include "ui/LocalUiManager.h"
 
 namespace {
-const char* kFirmwareVersion = "0.1.0-dev";
 constexpr uint32_t kTelemetryIntervalMs = 15000UL;
 
 const char* outputStateName(OutputState state) {
@@ -114,6 +114,10 @@ void MqttManager::setDiscoveryRequestHandler(DiscoveryRequestHandler handler) {
     discoveryRequestHandler_ = handler;
 }
 
+void MqttManager::setOtaCommandHandler(OtaCommandHandler handler) {
+    otaCommandHandler_ = handler;
+}
+
 bool MqttManager::connectIfNeeded(
     const SystemConfig& config,
     const OutputManager& outputs,
@@ -162,7 +166,7 @@ bool MqttManager::connectIfNeeded(
 void MqttManager::publishAvailability(const SystemConfig& config, const char* status) {
     const String payload =
         "{\"device_id\":\"" + config.deviceId + "\",\"status\":\"" + status
-        + "\",\"fw_version\":\"" + kFirmwareVersion + "\"}";
+        + "\",\"fw_version\":\"" + FirmwareVersion::kCurrent + "\"}";
     client_.publish(topicFor(config, "availability").c_str(), payload.c_str(), true);
 }
 
@@ -196,15 +200,20 @@ void MqttManager::publishState(
     const String heatingDescription = outputs.describeHeating();
     const String coolingDescription = outputs.describeCooling();
 
-    StaticJsonDocument<640> doc;
+    StaticJsonDocument<896> doc;
     doc["device_id"] = config.deviceId;
-    doc["fw_version"] = kFirmwareVersion;
+    doc["fw_version"] = FirmwareVersion::kCurrent;
     doc["ui"] = localUi.isHeadless() ? "headless" : "local";
     doc["mode"] = telemetry.mode;
     doc["heating"] = outputStateName(outputs.heatingState());
     doc["cooling"] = outputStateName(outputs.coolingState());
     doc["heating_desc"] = heatingDescription;
     doc["cooling_desc"] = coolingDescription;
+    doc["ota_status"] = telemetry.otaStatus;
+    doc["ota_channel"] = telemetry.otaChannel;
+    doc["ota_available"] = telemetry.otaUpdateAvailable;
+    doc["ota_progress_pct"] = telemetry.otaProgressPercent;
+    doc["ota_reboot_pending"] = telemetry.otaRebootPending;
     doc["controller_state"] = telemetry.controllerState;
     doc["controller_reason"] = telemetry.controllerReason;
     doc["automatic_control_active"] = telemetry.automaticControlActive;
@@ -224,8 +233,14 @@ void MqttManager::publishState(
     doc["hysteresis_c"] = telemetry.hysteresisC;
     doc["cooling_delay_s"] = telemetry.coolingDelaySeconds;
     doc["heating_delay_s"] = telemetry.heatingDelaySeconds;
+    if (!telemetry.otaTargetVersion.isEmpty()) {
+        doc["ota_target_version"] = telemetry.otaTargetVersion;
+    }
+    if (!telemetry.otaMessage.isEmpty()) {
+        doc["ota_message"] = telemetry.otaMessage;
+    }
 
-    char payload[640];
+    char payload[896];
     serializeJson(doc, payload, sizeof(payload));
     client_.publish(topicFor(config, "state").c_str(), payload, true);
 }
@@ -286,6 +301,37 @@ void MqttManager::publishKasaDiscovery(const SystemConfig& config, const String&
 
     const String payload = "{\"device_id\":\"" + config.deviceId + "\",\"result\":" + devicePayload + "}";
     client_.publish(topicFor(config, "discovery/kasa").c_str(), payload.c_str(), false);
+}
+
+void MqttManager::publishEvent(
+    const SystemConfig& config,
+    const char* eventName,
+    const char* result,
+    const char* message,
+    const TelemetrySnapshot& telemetry) {
+    if (!client_.connected()) {
+        return;
+    }
+
+    StaticJsonDocument<384> doc;
+    doc["device_id"] = config.deviceId;
+    doc["ts"] = millis() / 1000UL;
+    doc["event"] = eventName;
+    doc["fw_version"] = FirmwareVersion::kCurrent;
+    doc["result"] = result;
+    doc["ota_status"] = telemetry.otaStatus;
+    if (!telemetry.otaTargetVersion.isEmpty()) {
+        doc["target_version"] = telemetry.otaTargetVersion;
+    }
+    if (message != nullptr && message[0] != '\0') {
+        doc["message"] = message;
+    } else {
+        doc["message"] = nullptr;
+    }
+
+    char payload[384];
+    serializeJson(doc, payload, sizeof(payload));
+    client_.publish(topicFor(config, "event").c_str(), payload, false);
 }
 
 void MqttManager::publishConfigApplied(
@@ -369,6 +415,22 @@ void MqttManager::handleSystemConfig(const SystemConfig& currentConfig, const St
 
     if (doc.containsKey("heartbeat_interval_s")) {
         updated.heartbeat.intervalSeconds = doc["heartbeat_interval_s"] | updated.heartbeat.intervalSeconds;
+    }
+
+    JsonObject ota = doc["ota"];
+    if (!ota.isNull()) {
+        updated.ota.enabled = ota["enabled"] | updated.ota.enabled;
+        updated.ota.channel =
+            String(static_cast<const char*>(ota["channel"] | updated.ota.channel.c_str()));
+        updated.ota.checkStrategy = String(
+            static_cast<const char*>(ota["check_strategy"] | updated.ota.checkStrategy.c_str()));
+        updated.ota.checkIntervalSeconds =
+            ota["check_interval_s"] | updated.ota.checkIntervalSeconds;
+        updated.ota.manifestUrl = String(
+            static_cast<const char*>(ota["manifest_url"] | updated.ota.manifestUrl.c_str()));
+        updated.ota.caCertFingerprint = String(
+            static_cast<const char*>(ota["ca_cert_fingerprint"] | updated.ota.caCertFingerprint.c_str()));
+        updated.ota.allowHttp = ota["allow_http"] | updated.ota.allowHttp;
     }
 
     currentConfig_ = updated;
@@ -463,6 +525,15 @@ void MqttManager::handleCommand(const String& payload) {
         const String target = String(static_cast<const char*>(doc["target"] | ""));
         const String state = String(static_cast<const char*>(doc["state"] | ""));
         outputCommandHandler_(target, outputStateFromString(state));
+        return;
+    }
+
+    if ((command == "check_update" || command == "start_update") && otaCommandHandler_) {
+        JsonObject args = doc["args"];
+        const String channel = args.isNull()
+            ? String(static_cast<const char*>(doc["channel"] | ""))
+            : String(static_cast<const char*>(args["channel"] | ""));
+        otaCommandHandler_(command, channel);
     }
 }
 

--- a/firmware/src/network/ProvisioningManager.cpp
+++ b/firmware/src/network/ProvisioningManager.cpp
@@ -144,6 +144,13 @@ void ProvisioningManager::handleSave() {
     updated.localUi.enabled = server_.hasArg("local_ui_enabled");
     updated.display.enabled = server_.hasArg("display_enabled");
     updated.buttons.enabled = server_.hasArg("buttons_enabled");
+    updated.ota.enabled = server_.hasArg("ota_enabled");
+    updated.ota.channel = server_.arg("ota_channel");
+    updated.ota.checkStrategy = server_.arg("ota_check_strategy");
+    updated.ota.checkIntervalSeconds = static_cast<uint32_t>(server_.arg("ota_check_interval_s").toInt());
+    updated.ota.manifestUrl = server_.arg("ota_manifest_url");
+    updated.ota.caCertFingerprint = server_.arg("ota_ca_cert_fingerprint");
+    updated.ota.allowHttp = server_.hasArg("ota_allow_http");
 
     if (updated.mqtt.port == 0) {
         updated.mqtt.port = 1883;
@@ -155,6 +162,15 @@ void ProvisioningManager::handleSave() {
     if (updated.coolingOutput.port == 0) {
         updated.coolingOutput.port =
             updated.coolingOutput.driver == OutputDriverType::KasaLocal ? 9999 : 80;
+    }
+    if (updated.ota.channel.isEmpty()) {
+        updated.ota.channel = "stable";
+    }
+    if (updated.ota.checkStrategy.isEmpty()) {
+        updated.ota.checkStrategy = "manual";
+    }
+    if (updated.ota.checkIntervalSeconds == 0) {
+        updated.ota.checkIntervalSeconds = 86400;
     }
 
     const bool saved = onSave_ && onSave_(updated);
@@ -172,7 +188,7 @@ void ProvisioningManager::handleSave() {
 
 String ProvisioningManager::buildHtmlPage() const {
     String page;
-    page.reserve(4096);
+    page.reserve(6144);
     page += "<!doctype html><html><head><meta charset='utf-8'><title>brewesp setup</title>";
     page += "<style>body{font-family:sans-serif;max-width:820px;margin:2rem auto;padding:0 1rem;}label{display:block;margin-top:1rem;}input,select{width:100%;padding:.45rem;}fieldset{margin-top:1rem;}button{margin-top:1rem;padding:.7rem 1rem;}</style>";
     page += "</head><body><h1>brewesp setup</h1>";
@@ -241,6 +257,42 @@ String ProvisioningManager::buildHtmlPage() const {
         page += "checked";
     }
     page += "> Buttons connected</label>";
+    page += "</fieldset>";
+
+    page += "<fieldset><legend>OTA</legend>";
+    page += "<label><input type='checkbox' name='ota_enabled' ";
+    if (currentConfig_.ota.enabled) {
+        page += "checked";
+    }
+    page += "> Enable OTA updates</label>";
+    page += "<label>Manifest URL<input name='ota_manifest_url' value='" + htmlEscape(currentConfig_.ota.manifestUrl) + "'></label>";
+    page += "<label>Channel<select name='ota_channel'>";
+    for (const char* option : {"stable", "beta"}) {
+        page += "<option value='" + String(option) + "'";
+        if (currentConfig_.ota.channel == option) {
+            page += " selected";
+        }
+        page += ">" + String(option) + "</option>";
+    }
+    page += "</select></label>";
+    page += "<label>Check strategy<select name='ota_check_strategy'>";
+    for (const char* option : {"manual", "scheduled"}) {
+        page += "<option value='" + String(option) + "'";
+        if (currentConfig_.ota.checkStrategy == option) {
+            page += " selected";
+        }
+        page += ">" + String(option) + "</option>";
+    }
+    page += "</select></label>";
+    page += "<label>Check interval (seconds)<input name='ota_check_interval_s' type='number' value='"
+            + String(currentConfig_.ota.checkIntervalSeconds) + "'></label>";
+    page += "<label>TLS certificate fingerprint<input name='ota_ca_cert_fingerprint' value='"
+            + htmlEscape(currentConfig_.ota.caCertFingerprint) + "'></label>";
+    page += "<label><input type='checkbox' name='ota_allow_http' ";
+    if (currentConfig_.ota.allowHttp) {
+        page += "checked";
+    }
+    page += "> Allow plain HTTP OTA</label>";
     page += "</fieldset>";
 
     page += "<button type='submit'>Save and reboot</button></form></body></html>";

--- a/firmware/src/ota/OtaManager.cpp
+++ b/firmware/src/ota/OtaManager.cpp
@@ -1,0 +1,442 @@
+#include "ota/OtaManager.h"
+
+#include <HTTPClient.h>
+#include <Update.h>
+#include <WiFi.h>
+#include <WiFiClientSecure.h>
+#include <mbedtls/sha256.h>
+
+#include <ArduinoJson.h>
+#include <memory>
+
+#include "config/FirmwareVersion.h"
+
+namespace {
+constexpr uint16_t kDefaultHttpsPort = 443;
+constexpr uint16_t kDefaultHttpPort = 80;
+constexpr size_t kDownloadBufferSize = 1024;
+constexpr uint32_t kFermentationSchemaVersion = 1;
+
+String digestToHex(const unsigned char* digest, size_t length) {
+    static const char* kHex = "0123456789abcdef";
+    String value;
+    value.reserve(length * 2);
+    for (size_t i = 0; i < length; ++i) {
+        value += kHex[(digest[i] >> 4) & 0x0F];
+        value += kHex[digest[i] & 0x0F];
+    }
+    return value;
+}
+
+bool isDigitChar(char c) {
+    return c >= '0' && c <= '9';
+}
+}
+
+void OtaManager::begin(const SystemConfig& config) {
+    lastCheckStartedMs_ = 0;
+    setStatus(config.ota.enabled ? "idle" : "disabled");
+}
+
+bool OtaManager::shouldRunScheduledCheck(const SystemConfig& config, uint32_t nowMs) const {
+    if (!config.ota.enabled || config.ota.checkStrategy != "scheduled" || config.ota.checkIntervalSeconds == 0) {
+        return false;
+    }
+
+    if (lastCheckStartedMs_ == 0) {
+        return true;
+    }
+
+    return nowMs - lastCheckStartedMs_ >= config.ota.checkIntervalSeconds * 1000UL;
+}
+
+OtaManager::CheckResult OtaManager::checkForUpdate(const SystemConfig& config, const String& requestedChannel) {
+    CheckResult result;
+    lastCheckStartedMs_ = millis();
+
+    if (!config.ota.enabled) {
+        setStatus("disabled", "OTA disabled");
+        result.message = "OTA disabled";
+        return result;
+    }
+
+    if (WiFi.status() != WL_CONNECTED) {
+        setStatus("error", "Wi-Fi not connected");
+        result.message = "Wi-Fi not connected";
+        return result;
+    }
+
+    setStatus("checking");
+
+    Manifest manifest;
+    String error;
+    if (!fetchManifest(config, requestedChannel, manifest, error)) {
+        setStatus("error", error);
+        result.message = error;
+        return result;
+    }
+
+    result.success = true;
+    result.manifest = manifest;
+
+    if (compareVersions(manifest.version, FirmwareVersion::kCurrent) <= 0) {
+        setStatus("idle", "Already on latest version");
+        result.message = "Already on latest version";
+        return result;
+    }
+
+    setStatus("update_available", "Update available", manifest.version);
+    result.updateAvailable = true;
+    result.message = "Update available";
+    return result;
+}
+
+OtaManager::InstallResult OtaManager::startUpdate(const SystemConfig& config, const String& requestedChannel) {
+    InstallResult result;
+    CheckResult check = checkForUpdate(config, requestedChannel);
+    result.manifest = check.manifest;
+
+    if (!check.success) {
+        result.message = check.message;
+        return result;
+    }
+
+    if (!check.updateAvailable) {
+        result.success = true;
+        result.message = check.message;
+        return result;
+    }
+
+    setStatus("downloading", "Downloading firmware", check.manifest.version);
+
+    String error;
+    if (!downloadAndInstall(config, check.manifest, error)) {
+        setStatus("error", error, check.manifest.version);
+        result.message = error;
+        return result;
+    }
+
+    setStatus("rebooting", "Update installed, rebooting", check.manifest.version);
+    result.success = true;
+    result.message = "Update installed, rebooting";
+    return result;
+}
+
+const String& OtaManager::status() const {
+    return status_;
+}
+
+const String& OtaManager::message() const {
+    return message_;
+}
+
+const String& OtaManager::targetVersion() const {
+    return targetVersion_;
+}
+
+bool OtaManager::fetchManifest(
+    const SystemConfig& config,
+    const String& requestedChannel,
+    Manifest& manifest,
+    String& error) {
+    if (config.ota.manifestUrl.isEmpty()) {
+        error = "OTA manifest_url is not configured";
+        return false;
+    }
+
+    String body;
+    if (!httpGet(config.ota.manifestUrl, config.ota, body, error)) {
+        return false;
+    }
+
+    if (!parseManifest(body, manifest, error)) {
+        return false;
+    }
+
+    const String channel = effectiveChannel(config, requestedChannel);
+    if (manifest.channel != channel) {
+        error = "Manifest channel does not match requested OTA channel";
+        return false;
+    }
+
+    if (manifest.minSchemaVersion > kFermentationSchemaVersion) {
+        error = "Manifest requires a newer schema version";
+        return false;
+    }
+
+    return true;
+}
+
+bool OtaManager::downloadAndInstall(const SystemConfig& config, const Manifest& manifest, String& error) {
+    HTTPClient http;
+    std::unique_ptr<WiFiClient> client;
+    ParsedUrl parsedUrl;
+    if (!beginHttpRequest(manifest.downloadUrl, config.ota, http, client, parsedUrl, error)) {
+        return false;
+    }
+
+    const int contentLength = http.getSize();
+    if (contentLength <= 0) {
+        http.end();
+        error = "Firmware download is missing a valid content length";
+        return false;
+    }
+
+    if (!Update.begin(static_cast<size_t>(contentLength), U_FLASH)) {
+        http.end();
+        error = "Update.begin failed: " + String(Update.errorString());
+        return false;
+    }
+
+    mbedtls_sha256_context shaContext;
+    mbedtls_sha256_init(&shaContext);
+    mbedtls_sha256_starts_ret(&shaContext, 0);
+
+    WiFiClient* stream = http.getStreamPtr();
+    uint8_t buffer[kDownloadBufferSize];
+    size_t remaining = static_cast<size_t>(contentLength);
+
+    while (http.connected() && remaining > 0) {
+        const size_t available = stream->available();
+        if (available == 0) {
+            delay(1);
+            continue;
+        }
+
+        const size_t toRead = available > sizeof(buffer) ? sizeof(buffer) : available;
+        const size_t readCount = stream->readBytes(buffer, toRead);
+        if (readCount == 0) {
+            Update.abort();
+            http.end();
+            mbedtls_sha256_free(&shaContext);
+            error = "Firmware stream ended unexpectedly";
+            return false;
+        }
+
+        if (Update.write(buffer, readCount) != readCount) {
+            Update.abort();
+            http.end();
+            mbedtls_sha256_free(&shaContext);
+            error = "Update.write failed: " + String(Update.errorString());
+            return false;
+        }
+
+        mbedtls_sha256_update_ret(&shaContext, buffer, readCount);
+        remaining -= readCount;
+    }
+
+    unsigned char digest[32];
+    mbedtls_sha256_finish_ret(&shaContext, digest);
+    mbedtls_sha256_free(&shaContext);
+
+    if (remaining != 0) {
+        Update.abort();
+        http.end();
+        error = "Firmware download did not complete";
+        return false;
+    }
+
+    const String expectedSha = normalizeCompactHex(manifest.sha256);
+    const String actualSha = digestToHex(digest, sizeof(digest));
+    if (!expectedSha.isEmpty() && actualSha != expectedSha) {
+        Update.abort();
+        http.end();
+        error = "Firmware SHA256 mismatch";
+        return false;
+    }
+
+    if (!Update.end()) {
+        http.end();
+        error = "Update.end failed: " + String(Update.errorString());
+        return false;
+    }
+
+    http.end();
+    return true;
+}
+
+bool OtaManager::httpGet(const String& url, const OtaConfig& config, String& body, String& error) {
+    HTTPClient http;
+    std::unique_ptr<WiFiClient> client;
+    ParsedUrl parsedUrl;
+    if (!beginHttpRequest(url, config, http, client, parsedUrl, error)) {
+        return false;
+    }
+
+    body = http.getString();
+    http.end();
+    return true;
+}
+
+bool OtaManager::beginHttpRequest(
+    const String& url,
+    const OtaConfig& config,
+    HTTPClient& http,
+    std::unique_ptr<WiFiClient>& client,
+    ParsedUrl& parsedUrl,
+    String& error) {
+    if (!parseUrl(url, parsedUrl, error)) {
+        return false;
+    }
+
+    if (parsedUrl.scheme == "http" && !config.allowHttp) {
+        error = "HTTP downloads are disabled for OTA";
+        return false;
+    }
+
+    if (parsedUrl.scheme == "https") {
+        std::unique_ptr<WiFiClientSecure> secureClient(new WiFiClientSecure());
+        secureClient->setInsecure();
+        secureClient->setTimeout(15000);
+        client = std::move(secureClient);
+    } else {
+        std::unique_ptr<WiFiClient> plainClient(new WiFiClient());
+        plainClient->setTimeout(15000);
+        client = std::move(plainClient);
+    }
+
+    if (!http.begin(*client, url)) {
+        error = "Failed to open OTA URL";
+        return false;
+    }
+
+    http.setTimeout(15000);
+    const int statusCode = http.GET();
+    if (statusCode != HTTP_CODE_OK) {
+        error = "Unexpected HTTP status " + String(statusCode) + " for OTA request";
+        http.end();
+        return false;
+    }
+
+    if (parsedUrl.scheme == "https") {
+        if (config.caCertFingerprint.isEmpty()) {
+            error = "HTTPS OTA requires ca_cert_fingerprint";
+            http.end();
+            return false;
+        }
+
+        WiFiClientSecure& secureClient = static_cast<WiFiClientSecure&>(*client);
+        if (!secureClient.verify(config.caCertFingerprint.c_str(), parsedUrl.host.c_str())) {
+            error = "TLS fingerprint verification failed";
+            http.end();
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool OtaManager::parseManifest(const String& body, Manifest& manifest, String& error) const {
+    StaticJsonDocument<768> doc;
+    const DeserializationError jsonError = deserializeJson(doc, body);
+    if (jsonError) {
+        error = "Invalid OTA manifest JSON";
+        return false;
+    }
+
+    manifest.version = String(static_cast<const char*>(doc["version"] | ""));
+    manifest.channel = String(static_cast<const char*>(doc["channel"] | ""));
+    manifest.publishedAt = String(static_cast<const char*>(doc["published_at"] | ""));
+    manifest.minSchemaVersion = doc["min_schema_version"] | 0;
+    manifest.sha256 = String(static_cast<const char*>(doc["sha256"] | ""));
+    manifest.downloadUrl = String(static_cast<const char*>(doc["download_url"] | ""));
+
+    if (manifest.version.isEmpty() || manifest.channel.isEmpty() || manifest.downloadUrl.isEmpty()) {
+        error = "OTA manifest is missing required fields";
+        return false;
+    }
+
+    manifest.valid = true;
+    return true;
+}
+
+bool OtaManager::parseUrl(const String& url, ParsedUrl& parsedUrl, String& error) const {
+    const int schemeSeparator = url.indexOf("://");
+    if (schemeSeparator <= 0) {
+        error = "Invalid OTA URL";
+        return false;
+    }
+
+    parsedUrl.scheme = url.substring(0, schemeSeparator);
+    const int hostStart = schemeSeparator + 3;
+    const int pathStart = url.indexOf('/', hostStart);
+    const String authority = pathStart >= 0 ? url.substring(hostStart, pathStart) : url.substring(hostStart);
+    parsedUrl.path = pathStart >= 0 ? url.substring(pathStart) : "/";
+
+    const int portSeparator = authority.indexOf(':');
+    if (portSeparator >= 0) {
+        parsedUrl.host = authority.substring(0, portSeparator);
+        parsedUrl.port = static_cast<uint16_t>(authority.substring(portSeparator + 1).toInt());
+    } else {
+        parsedUrl.host = authority;
+        parsedUrl.port = parsedUrl.scheme == "https" ? kDefaultHttpsPort : kDefaultHttpPort;
+    }
+
+    if (parsedUrl.host.isEmpty()) {
+        error = "OTA URL is missing a host";
+        return false;
+    }
+
+    if (parsedUrl.scheme != "http" && parsedUrl.scheme != "https") {
+        error = "OTA URL must use http or https";
+        return false;
+    }
+
+    return true;
+}
+
+String OtaManager::effectiveChannel(const SystemConfig& config, const String& requestedChannel) const {
+    return requestedChannel.isEmpty() ? config.ota.channel : requestedChannel;
+}
+
+String OtaManager::normalizeCompactHex(const String& value) const {
+    String normalized;
+    normalized.reserve(value.length());
+    for (size_t i = 0; i < value.length(); ++i) {
+        const char ch = value[i];
+        if (ch == ':' || ch == ' ' || ch == '\t') {
+            continue;
+        }
+        normalized += static_cast<char>(tolower(ch));
+    }
+    return normalized;
+}
+
+int OtaManager::compareVersions(const String& lhs, const String& rhs) const {
+    size_t lhsIndex = 0;
+    size_t rhsIndex = 0;
+
+    while (lhsIndex < lhs.length() || rhsIndex < rhs.length()) {
+        while (lhsIndex < lhs.length() && !isDigitChar(lhs[lhsIndex])) {
+            ++lhsIndex;
+        }
+        while (rhsIndex < rhs.length() && !isDigitChar(rhs[rhsIndex])) {
+            ++rhsIndex;
+        }
+
+        unsigned long lhsValue = 0;
+        unsigned long rhsValue = 0;
+
+        while (lhsIndex < lhs.length() && isDigitChar(lhs[lhsIndex])) {
+            lhsValue = lhsValue * 10UL + static_cast<unsigned long>(lhs[lhsIndex] - '0');
+            ++lhsIndex;
+        }
+
+        while (rhsIndex < rhs.length() && isDigitChar(rhs[rhsIndex])) {
+            rhsValue = rhsValue * 10UL + static_cast<unsigned long>(rhs[rhsIndex] - '0');
+            ++rhsIndex;
+        }
+
+        if (lhsValue != rhsValue) {
+            return lhsValue > rhsValue ? 1 : -1;
+        }
+    }
+
+    return lhs.compareTo(rhs);
+}
+
+void OtaManager::setStatus(const String& status, const String& message, const String& targetVersion) {
+    status_ = status;
+    message_ = message;
+    targetVersion_ = targetVersion;
+}

--- a/infra/compose.yaml
+++ b/infra/compose.yaml
@@ -41,11 +41,18 @@ services:
       BREWESP_MQTT_USERNAME: ${BREWESP_MQTT_USERNAME:-}
       BREWESP_MQTT_PASSWORD: ${BREWESP_MQTT_PASSWORD:-}
       BREWESP_MQTT_TOPIC_PREFIX: ${BREWESP_MQTT_TOPIC_PREFIX:-brewesp}
+      BREWESP_FIRMWARE_DIR: /app/firmware-files
+      BREWESP_FIRMWARE_CHANNEL: ${BREWESP_FIRMWARE_CHANNEL:-stable}
+      BREWESP_FIRMWARE_FILENAME: ${BREWESP_FIRMWARE_FILENAME:-firmware.bin}
+      BREWESP_FIRMWARE_VERSION: ${BREWESP_FIRMWARE_VERSION:-0.1.0-dev}
+      BREWESP_FIRMWARE_MIN_SCHEMA_VERSION: "${BREWESP_FIRMWARE_MIN_SCHEMA_VERSION:-1}"
     depends_on:
       db:
         condition: service_healthy
     ports:
       - "8000:8000"
+    volumes:
+      - ../firmware/.pio/build/esp32dev:/app/firmware-files:ro
     restart: unless-stopped
 
 volumes:

--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -9,5 +9,6 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app ./app
+RUN mkdir -p /app/firmware-files
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/web/app/config.py
+++ b/services/web/app/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from pathlib import Path
 from urllib.parse import urlparse
 
 
@@ -18,6 +19,12 @@ class Settings:
     mqtt_password: str = os.getenv("BREWESP_MQTT_PASSWORD", "")
     mqtt_topic_prefix: str = os.getenv("BREWESP_MQTT_TOPIC_PREFIX", "brewesp")
     app_title: str = "brewesp control"
+    firmware_dir: Path = Path(os.getenv("BREWESP_FIRMWARE_DIR", "/app/firmware-files"))
+    firmware_base_url: str = os.getenv("BREWESP_FIRMWARE_BASE_URL", "")
+    firmware_channel: str = os.getenv("BREWESP_FIRMWARE_CHANNEL", "stable")
+    firmware_filename: str = os.getenv("BREWESP_FIRMWARE_FILENAME", "firmware.bin")
+    firmware_version: str = os.getenv("BREWESP_FIRMWARE_VERSION", "0.1.0-dev")
+    firmware_min_schema_version: int = int(os.getenv("BREWESP_FIRMWARE_MIN_SCHEMA_VERSION", "1"))
 
 
 def _resolve_settings() -> Settings:
@@ -35,6 +42,12 @@ def _resolve_settings() -> Settings:
         mqtt_password=parsed.password or base.mqtt_password,
         mqtt_topic_prefix=base.mqtt_topic_prefix,
         app_title=base.app_title,
+        firmware_dir=base.firmware_dir,
+        firmware_base_url=base.firmware_base_url,
+        firmware_channel=base.firmware_channel,
+        firmware_filename=base.firmware_filename,
+        firmware_version=base.firmware_version,
+        firmware_min_schema_version=base.firmware_min_schema_version,
     )
 
 

--- a/services/web/app/main.py
+++ b/services/web/app/main.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
+from hashlib import sha256
+from pathlib import Path
 
-from fastapi import FastAPI, Request
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from sqlalchemy import desc, select
@@ -39,6 +41,24 @@ app.mount("/static", StaticFiles(directory="app/static"), name="static")
 
 STALE_AFTER_SECONDS = 90
 OFFLINE_AFTER_SECONDS = 180
+
+
+def _firmware_file_path(filename: str | None = None) -> Path:
+    return settings.firmware_dir / (filename or settings.firmware_filename)
+
+
+def _firmware_download_url(request: Request, filename: str) -> str:
+    if settings.firmware_base_url:
+        return f"{settings.firmware_base_url.rstrip('/')}/firmware/files/{filename}"
+    return str(request.url_for("firmware_file", filename=filename))
+
+
+def _firmware_sha256(path: Path) -> str:
+    digest = sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def _serialize_heartbeats(heartbeats: list[DeviceHeartbeat]) -> list[dict]:
@@ -466,3 +486,37 @@ async def command_device(request: Request, device_id: str):
         mqtt_bridge.publish_command(device_id, payload)
 
     return RedirectResponse(url=f"/devices/{device_id}", status_code=303)
+
+
+@app.get("/firmware/manifest/{channel}.json")
+def firmware_manifest(request: Request, channel: str):
+    if channel != settings.firmware_channel:
+        raise HTTPException(status_code=404, detail="Firmware channel not found")
+
+    firmware_path = _firmware_file_path()
+    if not firmware_path.is_file():
+        raise HTTPException(status_code=404, detail="Firmware binary not available")
+
+    published_at = datetime.fromtimestamp(firmware_path.stat().st_mtime, tz=timezone.utc)
+    return JSONResponse(
+        {
+            "version": settings.firmware_version,
+            "channel": settings.firmware_channel,
+            "published_at": published_at.isoformat(),
+            "min_schema_version": settings.firmware_min_schema_version,
+            "sha256": _firmware_sha256(firmware_path),
+            "download_url": _firmware_download_url(request, firmware_path.name),
+        }
+    )
+
+
+@app.get("/firmware/files/{filename}", name="firmware_file")
+def firmware_file(filename: str):
+    if Path(filename).name != filename:
+        raise HTTPException(status_code=400, detail="Invalid firmware filename")
+
+    file_path = _firmware_file_path(filename)
+    if not file_path.is_file():
+        raise HTTPException(status_code=404, detail="Firmware file not found")
+
+    return FileResponse(file_path, media_type="application/octet-stream", filename=filename)


### PR DESCRIPTION
## What changed

- adds OTA-capable firmware partitions, OTA config persistence, MQTT `check_update` and `start_update`, and OTA state/event reporting in firmware
- adds web-hosted firmware manifest and binary endpoints with compose-mounted firmware artifacts
- aligns OTA architecture and MQTT contract docs with the implemented behavior

## Why

Issue #6 requires the OTA path described in the repo docs to be implemented end to end: manifest hosting, MQTT-triggered checks and updates, HTTP firmware download, and update result reporting.

## Validation

- `pio run` in `firmware/`
- `docker compose -f infra/compose.yaml config`
- `docker compose -f infra/compose.yaml build web`
- reviewer approve for docs and web tasks
- safety reviewer approve for firmware task
- real OTA hardware test on `brewesp-dev` via `COM4`
  - USB flashed OTA-capable base firmware
  - `check_update` returned `no_update` on same version
  - rebuilt a newer test firmware version
  - `check_update` returned `update_available`
  - `start_update` completed, device rebooted, and came back online on the new firmware version
  - final `check_update` returned `no_update`

## Residual risks

- HTTPS OTA with certificate fingerprint is not hardware-tested yet
- OTA under active heating/cooling lockout is not hardware-tested yet
- Project item status could not be moved from this environment
