### PR TITLE
[codex] Fail safe outputs when control is unavailable

### DIFF
--- a/firmware/include/controller/ControllerEngine.h
+++ b/firmware/include/controller/ControllerEngine.h
@@ -40,6 +40,7 @@ public:
     static const char* stateName(State state);
 
 private:
+    bool forceOutputsOff(OutputManager& outputs);
     bool setState(State nextState, const String& reason);
     uint32_t remainingSeconds(uint32_t lockedUntilMs, uint32_t nowMs) const;
     void updateSecondaryLimits(const FermentationConfig& config, const Inputs& inputs);

--- a/firmware/src/controller/ControllerEngine.cpp
+++ b/firmware/src/controller/ControllerEngine.cpp
@@ -19,11 +19,13 @@ bool ControllerEngine::update(const FermentationConfig& config, const Inputs& in
     status_.coolingDemand = false;
 
     if (config.mode != "thermostat" && config.mode != "profile") {
-        return setState(State::Idle, "mode inactive");
+        const bool outputsChanged = forceOutputsOff(outputs);
+        return setState(State::Idle, "mode inactive") || outputsChanged;
     }
 
     if (!inputs.hasPrimaryTemp) {
-        return setState(State::WaitingForSensor, "awaiting primary sensor");
+        const bool outputsChanged = forceOutputsOff(outputs);
+        return setState(State::Fault, "awaiting primary sensor") || outputsChanged;
     }
 
     status_.automaticControlActive = true;
@@ -103,6 +105,14 @@ bool ControllerEngine::update(const FermentationConfig& config, const Inputs& in
 
 const ControllerEngine::Status& ControllerEngine::status() const {
     return status_;
+}
+
+bool ControllerEngine::forceOutputsOff(OutputManager& outputs) {
+    const bool heatingChanged =
+        outputs.heatingState() != OutputState::Off ? outputs.setHeating(OutputState::Off) : false;
+    const bool coolingChanged =
+        outputs.coolingState() != OutputState::Off ? outputs.setCooling(OutputState::Off) : false;
+    return heatingChanged || coolingChanged;
 }
 
 const char* ControllerEngine::stateName(State state) {


### PR DESCRIPTION
## What changed
- force both heating and cooling off when automatic control is inactive
- treat a missing primary sensor as a controller fault instead of a passive waiting state

## Why
The controller could return early on inactive mode or missing primary temperature without first commanding the outputs off. That meant a relay could stay active after control authority was lost.

## Impact
This hardens the controller's fail-safe behavior for sensor loss and other no-control paths.

## Validation
- pio run