### PR TITLE
[codex] Keep control active during Wi-Fi recovery

### DIFF
--- a/firmware/include/App.h
+++ b/firmware/include/App.h
@@ -36,6 +36,7 @@ private:
     void beginNormalMode();
     void startProvisioningMode(const char* reason);
     void ensureWifiConnected();
+    void updateControlLoop();
     void handleSystemConfig(const SystemConfig& updatedConfig);
     void handleFermentationConfig(const FermentationConfig& updatedConfig);
     void handleOutputCommand(const String& target, OutputState state);

--- a/firmware/src/App.cpp
+++ b/firmware/src/App.cpp
@@ -38,10 +38,9 @@ void App::begin() {
 
     if (config_.wifi.ssid.isEmpty()) {
         startProvisioningMode("missing Wi-Fi config");
-        return;
+    } else {
+        beginNormalMode();
     }
-
-    beginNormalMode();
 }
 
 void App::update() {
@@ -52,20 +51,10 @@ void App::update() {
             delay(1000);
             ESP.restart();
         }
-        return;
     }
 
     ensureWifiConnected();
-    localUi_.update();
-    outputs_.update();
-    sensors_.update(config_);
-    if (isOtaLockoutActive()) {
-        outputs_.setHeating(OutputState::Off);
-        outputs_.setCooling(OutputState::Off);
-        outputs_.refreshStates();
-    } else if (controller_.update(fermentationConfig_, buildControllerInputs(), outputs_)) {
-        mqtt_.publishState(config_, outputs_, localUi_, buildTelemetrySnapshot());
-    }
+    updateControlLoop();
     mqtt_.update(config_, outputs_, localUi_, buildTelemetrySnapshot());
     processPendingOtaCommand();
     if (ota_.shouldRunScheduledCheck(config_, millis())) {
@@ -109,6 +98,19 @@ void App::beginNormalMode() {
     WiFi.mode(WIFI_STA);
     ensureWifiConnected();
     mqtt_.begin(config_);
+}
+
+void App::updateControlLoop() {
+    localUi_.update();
+    outputs_.update();
+    sensors_.update(config_);
+    if (isOtaLockoutActive()) {
+        outputs_.setHeating(OutputState::Off);
+        outputs_.setCooling(OutputState::Off);
+        outputs_.refreshStates();
+    } else if (controller_.update(fermentationConfig_, buildControllerInputs(), outputs_)) {
+        mqtt_.publishState(config_, outputs_, localUi_, buildTelemetrySnapshot());
+    }
 }
 
 void App::handleSystemConfig(const SystemConfig& updatedConfig) {
@@ -474,9 +476,13 @@ void App::runKasaDiscovery() {
 }
 
 void App::startProvisioningMode(const char* reason) {
-    provisioningMode_ = true;
+    if (provisioningMode_ && provisioning_.isActive()) {
+        return;
+    }
+
     Serial.printf("[prov] starting provisioning mode reason=%s\r\n", reason);
-    provisioning_.begin(
+    wifiConnectStartedMs_ = 0;
+    provisioningMode_ = provisioning_.begin(
         config_,
         [this](const SystemConfig& updatedConfig) {
             config_ = updatedConfig;
@@ -485,7 +491,13 @@ void App::startProvisioningMode(const char* reason) {
 }
 
 void App::ensureWifiConnected() {
+    if (config_.wifi.ssid.isEmpty()) {
+        wifiConnectStartedMs_ = 0;
+        return;
+    }
+
     if (WiFi.status() == WL_CONNECTED) {
+        wifiConnectStartedMs_ = 0;
         return;
     }
 
@@ -498,6 +510,10 @@ void App::ensureWifiConnected() {
 
     if (millis() - wifiConnectStartedMs_
         < config_.wifi.recoveryAp.startAfterWifiFailureSeconds * 1000UL) {
+        return;
+    }
+
+    if (provisioningMode_) {
         return;
     }
 

--- a/firmware/src/network/ProvisioningManager.cpp
+++ b/firmware/src/network/ProvisioningManager.cpp
@@ -57,16 +57,20 @@ bool ProvisioningManager::begin(const SystemConfig& currentConfig, SaveCallback 
     currentConfig_ = currentConfig;
     onSave_ = std::move(onSave);
     restartRequested_ = false;
+    active_ = false;
 
     const IPAddress apIp = parseIpOrDefault(currentConfig_.wifi.recoveryAp.ip);
     const IPAddress gateway = apIp;
     const IPAddress subnet(255, 255, 255, 0);
+    const bool keepStationActive = !currentConfig_.wifi.ssid.isEmpty();
 
     accessPointSsid_ = buildRecoverySsid(currentConfig_);
     const String apPassword = currentConfig_.wifi.recoveryAp.password;
 
-    WiFi.disconnect(true);
-    WiFi.mode(WIFI_AP);
+    if (!keepStationActive) {
+        WiFi.disconnect(true);
+    }
+    WiFi.mode(keepStationActive ? WIFI_AP_STA : WIFI_AP);
     WiFi.softAPConfig(apIp, gateway, subnet);
 
     const bool apStarted = WiFi.softAP(


### PR DESCRIPTION
## What changed
- keep the control loop running while recovery/provisioning mode is active
- reset the Wi-Fi failure timer after a successful reconnect
- start the recovery AP in AP+STA mode when saved Wi-Fi credentials exist so the station side can keep reconnecting

## Why
A Wi-Fi timeout could push the device into provisioning mode and then stop the normal control loop entirely. Because the timeout timestamp was never reset after reconnect, even a later short disconnect could trigger that path unexpectedly.

## Impact
The controller now keeps local temperature control running during Wi-Fi recovery and is much less likely to enter recovery mode because of a transient network interruption.

## Validation
- pio run