### PR TITLE
[codex] Add sensor fault failsafe and surface it in the UI

### DIFF
--- a/docs/mqtt-contract.md
+++ b/docs/mqtt-contract.md
@@ -71,12 +71,12 @@ Payload example:
 ```json
 {
   "device_id": "fermenter-01",
-  "ts": "2026-03-29T14:00:00Z",
   "uptime_s": 86400,
   "wifi_rssi": -58,
   "heap_free": 183424,
-  "active_config_version": 4,
-  "fault": null
+  "ui": "headless",
+  "heating": "off",
+  "cooling": "off"
 }
 ```
 
@@ -93,14 +93,26 @@ Payload example:
 ```json
 {
   "device_id": "fermenter-01",
-  "ts": "2026-03-29T14:00:00Z",
+  "ts": 1743343200,
   "temp_primary_c": 18.42,
   "temp_secondary_c": 17.1,
-  "temp_beer_c": 18.42,
-  "temp_chamber_c": 17.1,
   "setpoint_c": 18.5,
   "effective_target_c": 18.7,
   "mode": "profile",
+  "controller_state": "idle",
+  "controller_reason": "within hysteresis",
+  "automatic_control_active": true,
+  "active_config_version": 4,
+  "secondary_sensor_enabled": false,
+  "control_sensor": "primary",
+  "beer_probe_present": true,
+  "beer_probe_valid": true,
+  "beer_probe_stale": false,
+  "beer_probe_rom": "28ff112233445566",
+  "chamber_probe_present": true,
+  "chamber_probe_valid": true,
+  "chamber_probe_stale": false,
+  "chamber_probe_rom": "28ffaa9988776655",
   "profile_id": "ale-primary",
   "profile_step_id": "rise",
   "heating": false,
@@ -127,7 +139,6 @@ Payload example:
 ```json
 {
   "device_id": "fermenter-01",
-  "ts": "2026-03-29T14:00:00Z",
   "ui": "headless",
   "mode": "profile",
   "setpoint_c": 18.5,
@@ -144,17 +155,19 @@ Payload example:
   "cooling": "off",
   "heating_desc": "gpio 25 off",
   "cooling_desc": "kasa 192.168.1.88 off",
-  "controller_state": "holding",
-  "controller_reason": "profile_step_active",
+  "controller_state": "idle",
+  "controller_reason": "within hysteresis",
   "automatic_control_active": true,
   "active_config_version": 4,
   "secondary_sensor_enabled": false,
   "control_sensor": "primary",
   "beer_probe_present": true,
   "beer_probe_valid": true,
+  "beer_probe_stale": false,
   "beer_probe_rom": "28ff112233445566",
   "chamber_probe_present": true,
   "chamber_probe_valid": true,
+  "chamber_probe_stale": false,
   "chamber_probe_rom": "28ffaa9988776655",
   "profile_runtime": {
     "active_profile_id": "ale-primary",
@@ -178,6 +191,10 @@ Additional OTA fields:
 - `ota_progress_pct` is currently coarse-grained; the current firmware reports `100`
   when the new image is staged and reboot is pending, otherwise `0`
 - `heating` and `cooling` in `state` are string enums: `on`, `off`, or `unknown`
+- `fault` in `state` and `telemetry` is either `null` or a short string such as
+  `beer sensor stale` or `chamber sensor missing`
+- `beer_probe_stale` and `chamber_probe_stale` indicate firmware-side stale detection;
+  the current firmware uses a fixed `30` second timeout for this fault model
 
 `profile_runtime` is the runtime truth for an active profile. Frontends should
 use it instead of inferring progress from desired config alone.
@@ -200,6 +217,17 @@ Expected `profile_runtime.phase` values:
 Optional raw event stream for archival or analytics.
 
 This can initially be identical to `telemetry` and later be split if needed.
+
+### Sensor fault semantics
+
+- the controller publishes per-probe `present`, `valid`, and `stale` flags for
+  both beer and chamber probes
+- `fault` is controller-scoped, not a generic alarm bucket
+- `fault` becomes non-null only when the selected primary control sensor is
+  missing, invalid, or stale
+- when `fault` is non-null, the firmware forces both outputs off locally
+- a non-primary probe may still report `stale` or `invalid` without forcing a
+  controller fault by itself
 
 ### `config/desired`
 
@@ -290,7 +318,6 @@ Payload example:
 ```json
 {
   "device_id": "fermenter-01",
-  "ts": "2026-03-29T14:00:03Z",
   "requested_version": 4,
   "applied_version": 4,
   "result": "ok",
@@ -303,7 +330,6 @@ If validation fails:
 ```json
 {
   "device_id": "fermenter-01",
-  "ts": "2026-03-29T14:00:03Z",
   "requested_version": 4,
   "applied_version": 3,
   "result": "error",

--- a/firmware/include/controller/ControllerEngine.h
+++ b/firmware/include/controller/ControllerEngine.h
@@ -23,6 +23,7 @@ public:
         bool hasSecondaryTemp = false;
         float secondaryTempC = 0.0f;
         uint32_t nowMs = 0;
+        String faultReason;
     };
 
     struct Status {

--- a/firmware/include/network/MqttManager.h
+++ b/firmware/include/network/MqttManager.h
@@ -32,9 +32,11 @@ public:
         String controlSensor = "primary";
         bool beerProbePresent = false;
         bool beerProbeValid = false;
+        bool beerProbeStale = false;
         String beerProbeRom;
         bool chamberProbePresent = false;
         bool chamberProbeValid = false;
+        bool chamberProbeStale = false;
         String chamberProbeRom;
         String profileId;
         String profileStepId;
@@ -55,6 +57,7 @@ public:
         bool otaUpdateAvailable = false;
         uint8_t otaProgressPercent = 0;
         bool otaRebootPending = false;
+        String fault;
     };
 
     using SystemConfigHandler = std::function<void(const SystemConfig&)>;

--- a/firmware/src/App.cpp
+++ b/firmware/src/App.cpp
@@ -6,6 +6,21 @@ namespace {
 const uint32_t kHeartbeatLogIntervalMs = 5000;
 constexpr float kDefaultSetpointC = 20.0f;
 constexpr uint32_t kProfileRuntimePersistIntervalMs = 300000UL;
+constexpr uint32_t kSensorStaleAfterMs = 30000UL;
+
+bool isSensorStale(const SensorManager::Reading& reading, uint32_t nowMs) {
+    return reading.updatedAtMs != 0 && static_cast<uint32_t>(nowMs - reading.updatedAtMs) > kSensorStaleAfterMs;
+}
+
+String sensorFaultReason(const char* sensorName, const SensorManager::Reading& reading, bool stale) {
+    if (stale) {
+        return String(sensorName) + " sensor stale";
+    }
+    if (!reading.present) {
+        return String(sensorName) + " sensor missing";
+    }
+    return String(sensorName) + " sensor invalid";
+}
 }
 
 void App::begin() {
@@ -185,6 +200,17 @@ void App::handleOutputCommand(const String& target, OutputState state) {
         return;
     }
 
+    const ControllerEngine::Inputs currentInputs = buildControllerInputs();
+    const bool sensorFaultActive = !currentInputs.hasPrimaryTemp;
+
+    if (state == OutputState::On && sensorFaultActive) {
+        Serial.printf(
+            "[app] ignoring output-on command during sensor fault target=%s reason=%s\r\n",
+            target.c_str(),
+            currentInputs.faultReason.isEmpty() ? "sensor fault active" : currentInputs.faultReason.c_str());
+        return;
+    }
+
     if (isOtaLockoutActive()) {
         Serial.printf(
             "[app] ignoring output command during OTA reboot pending target=%s state=%s\r\n",
@@ -358,6 +384,8 @@ MqttManager::TelemetrySnapshot App::buildTelemetrySnapshot() const {
     const SensorManager::Reading& beerProbe = sensors_.beerProbe();
     const SensorManager::Reading& chamberProbe = sensors_.chamberProbe();
     const uint32_t nowMs = millis();
+    const bool beerProbeStale = isSensorStale(beerProbe, nowMs);
+    const bool chamberProbeStale = isSensorStale(chamberProbe, nowMs);
     telemetry.hasSetpoint = true;
     telemetry.setpointC = fermentationConfig_.thermostat.setpointC;
     telemetry.hysteresisC = fermentationConfig_.thermostat.hysteresisC;
@@ -370,24 +398,27 @@ MqttManager::TelemetrySnapshot App::buildTelemetrySnapshot() const {
     telemetry.automaticControlActive = controllerStatus.automaticControlActive;
     telemetry.secondarySensorEnabled = fermentationConfig_.sensors.secondaryEnabled;
     telemetry.controlSensor = fermentationConfig_.sensors.controlSensor;
-    if (beerProbe.valid) {
+    if (beerProbe.valid && !beerProbeStale) {
         telemetry.hasPrimaryTemp = true;
         telemetry.primaryTempC = beerProbe.tempC + fermentationConfig_.sensors.primaryOffsetC;
     }
     telemetry.beerProbePresent = beerProbe.present;
     telemetry.beerProbeValid = beerProbe.valid;
+    telemetry.beerProbeStale = beerProbeStale;
     if (beerProbe.present) {
         telemetry.beerProbeRom = sensors_.beerProbeRom();
     }
-    if (chamberProbe.valid) {
+    if (chamberProbe.valid && !chamberProbeStale) {
         telemetry.hasSecondaryTemp = true;
         telemetry.secondaryTempC = chamberProbe.tempC + fermentationConfig_.sensors.secondaryOffsetC;
     }
     telemetry.chamberProbePresent = chamberProbe.present;
     telemetry.chamberProbeValid = chamberProbe.valid;
+    telemetry.chamberProbeStale = chamberProbeStale;
     if (chamberProbe.present) {
         telemetry.chamberProbeRom = sensors_.chamberProbeRom();
     }
+    telemetry.fault = controllerStatus.state == ControllerEngine::State::Fault ? controllerStatus.reason : String();
     if (profileRuntime_.active) {
         telemetry.hasProfileRuntime = true;
         telemetry.profileId = profileRuntime_.activeProfileId;
@@ -422,19 +453,29 @@ ControllerEngine::Inputs App::buildControllerInputs() const {
     const SensorManager::Reading& beerProbe = sensors_.beerProbe();
     const SensorManager::Reading& chamberProbe = sensors_.chamberProbe();
     inputs.nowMs = millis();
+    const bool beerProbeStale = isSensorStale(beerProbe, inputs.nowMs);
+    const bool chamberProbeStale = isSensorStale(chamberProbe, inputs.nowMs);
+    const bool beerProbeValid = beerProbe.valid && !beerProbeStale;
+    const bool chamberProbeValid = chamberProbe.valid && !chamberProbeStale;
     const bool useSecondaryAsControl =
         fermentationConfig_.sensors.secondaryEnabled && fermentationConfig_.sensors.controlSensor == "secondary";
 
     if (useSecondaryAsControl) {
-        inputs.hasPrimaryTemp = chamberProbe.valid;
+        inputs.hasPrimaryTemp = chamberProbeValid;
         inputs.primaryTempC = chamberProbe.tempC + fermentationConfig_.sensors.secondaryOffsetC;
-        inputs.hasSecondaryTemp = beerProbe.valid;
+        inputs.hasSecondaryTemp = beerProbeValid;
         inputs.secondaryTempC = beerProbe.tempC + fermentationConfig_.sensors.primaryOffsetC;
     } else {
-        inputs.hasPrimaryTemp = beerProbe.valid;
+        inputs.hasPrimaryTemp = beerProbeValid;
         inputs.primaryTempC = beerProbe.tempC + fermentationConfig_.sensors.primaryOffsetC;
-        inputs.hasSecondaryTemp = chamberProbe.valid;
+        inputs.hasSecondaryTemp = chamberProbeValid;
         inputs.secondaryTempC = chamberProbe.tempC + fermentationConfig_.sensors.secondaryOffsetC;
+    }
+    if (!inputs.hasPrimaryTemp) {
+        inputs.faultReason = sensorFaultReason(
+            useSecondaryAsControl ? "chamber" : "beer",
+            useSecondaryAsControl ? chamberProbe : beerProbe,
+            useSecondaryAsControl ? chamberProbeStale : beerProbeStale);
     }
     return inputs;
 }

--- a/firmware/src/controller/ControllerEngine.cpp
+++ b/firmware/src/controller/ControllerEngine.cpp
@@ -25,7 +25,8 @@ bool ControllerEngine::update(const FermentationConfig& config, const Inputs& in
 
     if (!inputs.hasPrimaryTemp) {
         const bool outputsChanged = forceOutputsOff(outputs);
-        return setState(State::Fault, "awaiting primary sensor") || outputsChanged;
+        const String reason = inputs.faultReason.isEmpty() ? "primary sensor invalid" : inputs.faultReason;
+        return setState(State::Fault, reason) || outputsChanged;
     }
 
     status_.automaticControlActive = true;
@@ -34,10 +35,11 @@ bool ControllerEngine::update(const FermentationConfig& config, const Inputs& in
     const float hysteresisC = config.thermostat.hysteresisC;
     const float heatThresholdC = setpointC - hysteresisC;
     const float coolThresholdC = setpointC + hysteresisC;
+    const float processTempC = inputs.primaryTempC;
 
-    if (inputs.primaryTempC <= heatThresholdC) {
+    if (processTempC <= heatThresholdC) {
         status_.heatingDemand = true;
-    } else if (inputs.primaryTempC >= coolThresholdC) {
+    } else if (processTempC >= coolThresholdC) {
         status_.coolingDemand = true;
     }
 

--- a/firmware/src/network/MqttManager.cpp
+++ b/firmware/src/network/MqttManager.cpp
@@ -250,10 +250,17 @@ void MqttManager::publishState(
     doc["control_sensor"] = telemetry.controlSensor;
     doc["beer_probe_present"] = telemetry.beerProbePresent;
     doc["beer_probe_valid"] = telemetry.beerProbeValid;
+    doc["beer_probe_stale"] = telemetry.beerProbeStale;
     doc["beer_probe_rom"] = telemetry.beerProbeRom;
     doc["chamber_probe_present"] = telemetry.chamberProbePresent;
     doc["chamber_probe_valid"] = telemetry.chamberProbeValid;
+    doc["chamber_probe_stale"] = telemetry.chamberProbeStale;
     doc["chamber_probe_rom"] = telemetry.chamberProbeRom;
+    if (!telemetry.fault.isEmpty()) {
+        doc["fault"] = telemetry.fault;
+    } else {
+        doc["fault"] = nullptr;
+    }
     if (telemetry.hasSetpoint) {
         doc["setpoint_c"] = telemetry.setpointC;
     } else {
@@ -307,10 +314,17 @@ void MqttManager::publishTelemetry(
     doc["control_sensor"] = telemetry.controlSensor;
     doc["beer_probe_present"] = telemetry.beerProbePresent;
     doc["beer_probe_valid"] = telemetry.beerProbeValid;
+    doc["beer_probe_stale"] = telemetry.beerProbeStale;
     doc["beer_probe_rom"] = telemetry.beerProbeRom;
     doc["chamber_probe_present"] = telemetry.chamberProbePresent;
     doc["chamber_probe_valid"] = telemetry.chamberProbeValid;
+    doc["chamber_probe_stale"] = telemetry.chamberProbeStale;
     doc["chamber_probe_rom"] = telemetry.chamberProbeRom;
+    if (!telemetry.fault.isEmpty()) {
+        doc["fault"] = telemetry.fault;
+    } else {
+        doc["fault"] = nullptr;
+    }
     doc["heating"] = outputs.heatingState() == OutputState::On;
     doc["cooling"] = outputs.coolingState() == OutputState::On;
 

--- a/firmware/src/sensor/SensorManager.cpp
+++ b/firmware/src/sensor/SensorManager.cpp
@@ -153,7 +153,6 @@ void SensorManager::assignProbeAddresses(const SystemConfig& config) {
 void SensorManager::readProbe(ReadState& probe, uint32_t nowMs) {
     probe.reading.present = false;
     probe.reading.valid = false;
-    probe.reading.updatedAtMs = 0;
 
     if (!probe.configured) {
         return;

--- a/services/web/app/main.py
+++ b/services/web/app/main.py
@@ -126,10 +126,27 @@ def _output_button_state(current_state: str | None, expected: str) -> str:
     return "unknown"
 
 
+def _sensor_status_label(present: bool | None, valid: bool | None, stale: bool | None) -> str:
+    if not present:
+        return "missing"
+    if stale:
+        return "stale"
+    if valid:
+        return "present"
+    return "invalid"
+
+
 def _device_live_payload(device: Device, now: datetime) -> dict:
     device = _apply_display_status(device, now)
     fermentation_config = device.fermentation_config
     state_payload = device.last_payload or {}
+    beer_probe_present = state_payload.get("beer_probe_present")
+    beer_probe_valid = state_payload.get("beer_probe_valid")
+    beer_probe_stale = state_payload.get("beer_probe_stale")
+    chamber_probe_present = state_payload.get("chamber_probe_present")
+    chamber_probe_valid = state_payload.get("chamber_probe_valid")
+    chamber_probe_stale = state_payload.get("chamber_probe_stale")
+    fault = state_payload.get("fault")
     return {
         "device_id": device.device_id,
         "display_status": device.display_status,
@@ -147,13 +164,21 @@ def _device_live_payload(device: Device, now: datetime) -> dict:
         "last_mode": device.last_mode,
         "controller_state": state_payload.get("controller_state"),
         "controller_reason": state_payload.get("controller_reason"),
+        "fault": fault,
+        "has_fault": bool(fault),
         "automatic_control_active": state_payload.get("automatic_control_active"),
         "active_config_version": state_payload.get("active_config_version"),
-        "beer_probe_present": state_payload.get("beer_probe_present"),
-        "beer_probe_valid": state_payload.get("beer_probe_valid"),
+        "beer_probe_present": beer_probe_present,
+        "beer_probe_valid": beer_probe_valid,
+        "beer_probe_stale": beer_probe_stale,
+        "beer_probe_status": _sensor_status_label(beer_probe_present, beer_probe_valid, beer_probe_stale),
         "beer_probe_rom": state_payload.get("beer_probe_rom"),
-        "chamber_probe_present": state_payload.get("chamber_probe_present"),
-        "chamber_probe_valid": state_payload.get("chamber_probe_valid"),
+        "chamber_probe_present": chamber_probe_present,
+        "chamber_probe_valid": chamber_probe_valid,
+        "chamber_probe_stale": chamber_probe_stale,
+        "chamber_probe_status": _sensor_status_label(
+            chamber_probe_present, chamber_probe_valid, chamber_probe_stale
+        ),
         "chamber_probe_rom": state_payload.get("chamber_probe_rom"),
         "secondary_sensor_enabled": state_payload.get("secondary_sensor_enabled"),
         "control_sensor": state_payload.get("control_sensor"),
@@ -464,6 +489,7 @@ def device_detail(request: Request, device_id: str):
         ).all()
 
         assignments = {assignment.role: assignment for assignment in device.output_assignments}
+        live_payload = _device_live_payload(device, now)
 
     return templates.TemplateResponse(
         request,
@@ -471,6 +497,7 @@ def device_detail(request: Request, device_id: str):
         {
             "device": device,
             "fermentation_config": device.fermentation_config,
+            "live_payload": live_payload,
             "heartbeats": list(reversed(_serialize_heartbeats(heartbeats))),
             "telemetry": list(reversed(_serialize_telemetry(telemetry))),
             "discovered_relays": discovered_relays,

--- a/services/web/app/static/app.js
+++ b/services/web/app/static/app.js
@@ -38,6 +38,27 @@ function withDerivedButtonStates(payload) {
   return next;
 }
 
+function sensorStatusFromPayload(payload, prefix) {
+  const present = payload?.[`${prefix}_probe_present`];
+  const valid = payload?.[`${prefix}_probe_valid`];
+  const stale = payload?.[`${prefix}_probe_stale`];
+
+  if (!present) {
+    return "missing";
+  }
+  if (stale) {
+    return "stale";
+  }
+  if (valid) {
+    return "present";
+  }
+  return "invalid";
+}
+
+function hasPayloadField(payload, field) {
+  return Object.prototype.hasOwnProperty.call(payload || {}, field);
+}
+
 function formatMetric(value, format) {
   if (value === null || value === undefined || Number.isNaN(value)) {
     return "n/a";
@@ -256,6 +277,9 @@ function applyLiveState(payload) {
   const modeChip = document.querySelector("#mode-chip");
   const controllerState = document.querySelector("#controller-state");
   const controllerReason = document.querySelector("#controller-reason");
+  const controllerFaultState = document.querySelector("#controller-fault-state");
+  const controllerFaultBanner = document.querySelector("#controller-fault-banner");
+  const controllerFaultText = document.querySelector("#controller-fault-text");
   const beerProbeStatus = document.querySelector("#beer-probe-status");
   const beerProbeRom = document.querySelector("#beer-probe-rom");
   const chamberProbeStatus = document.querySelector("#chamber-probe-status");
@@ -275,81 +299,104 @@ function applyLiveState(payload) {
   const configMessage = document.querySelector("#config-message");
   const desiredVersionInput = document.querySelector("#desired-version-input");
 
-  if (status) {
+  if (status && hasPayloadField(payload, "display_status")) {
     status.textContent = payload.display_status;
   }
-  if (mqtt) {
+  if (mqtt && hasPayloadField(payload, "mqtt_connected")) {
     mqtt.textContent = payload.mqtt_connected ? "connected" : "disconnected";
   }
-  if (lastHeartbeat) {
+  if (lastHeartbeat && (hasPayloadField(payload, "last_heartbeat_label") || hasPayloadField(payload, "last_heartbeat_at"))) {
     lastHeartbeat.textContent = payload.last_heartbeat_label || payload.last_heartbeat_at || "never";
   }
-  if (modeChip) {
+  if (modeChip && hasPayloadField(payload, "last_mode")) {
     modeChip.textContent = payload.last_mode || "mode n/a";
   }
-  if (controllerState) {
+  if (controllerState && hasPayloadField(payload, "controller_state")) {
     controllerState.textContent = payload.controller_state || "unknown";
   }
-  if (controllerReason) {
-    controllerReason.textContent = payload.controller_reason || "n/a";
+  const hasFaultField = hasPayloadField(payload, "fault");
+  const faultValue = hasFaultField ? payload.fault : null;
+  if (controllerReason && (hasFaultField || hasPayloadField(payload, "controller_reason"))) {
+    controllerReason.textContent = faultValue || payload.controller_reason || "n/a";
   }
-  if (beerProbeStatus) {
-    beerProbeStatus.textContent = payload.beer_probe_present
-      ? (payload.beer_probe_valid ? "present" : "invalid")
-      : "missing";
+  if (controllerFaultState && hasFaultField) {
+    controllerFaultState.textContent = faultValue || "none";
   }
-  if (beerProbeRom) {
+  if (controllerFaultBanner && hasFaultField) {
+    const hasFault = Boolean(faultValue);
+    controllerFaultBanner.hidden = !hasFault;
+    controllerFaultBanner.classList.toggle("is-active", hasFault);
+  }
+  if (controllerFaultText && hasFaultField) {
+    controllerFaultText.textContent = faultValue || "none";
+  }
+  if (beerProbeStatus && (
+    hasPayloadField(payload, "beer_probe_status")
+    || hasPayloadField(payload, "beer_probe_present")
+    || hasPayloadField(payload, "beer_probe_valid")
+    || hasPayloadField(payload, "beer_probe_stale")
+  )) {
+    const status = payload.beer_probe_status || sensorStatusFromPayload(payload, "beer");
+    beerProbeStatus.textContent = status;
+    beerProbeStatus.className = `sensor-state ${status}`;
+  }
+  if (beerProbeRom && hasPayloadField(payload, "beer_probe_rom")) {
     beerProbeRom.textContent = payload.beer_probe_rom || "n/a";
   }
-  if (chamberProbeStatus) {
-    chamberProbeStatus.textContent = payload.chamber_probe_present
-      ? (payload.chamber_probe_valid ? "present" : "invalid")
-      : "missing";
+  if (chamberProbeStatus && (
+    hasPayloadField(payload, "chamber_probe_status")
+    || hasPayloadField(payload, "chamber_probe_present")
+    || hasPayloadField(payload, "chamber_probe_valid")
+    || hasPayloadField(payload, "chamber_probe_stale")
+  )) {
+    const status = payload.chamber_probe_status || sensorStatusFromPayload(payload, "chamber");
+    chamberProbeStatus.textContent = status;
+    chamberProbeStatus.className = `sensor-state ${status}`;
   }
-  if (chamberProbeRom) {
+  if (chamberProbeRom && hasPayloadField(payload, "chamber_probe_rom")) {
     chamberProbeRom.textContent = payload.chamber_probe_rom || "n/a";
   }
-  if (secondaryEnabled) {
+  if (secondaryEnabled && hasPayloadField(payload, "secondary_sensor_enabled")) {
     secondaryEnabled.textContent = payload.secondary_sensor_enabled ? "yes" : "no";
   }
-  if (controlSensor) {
+  if (controlSensor && hasPayloadField(payload, "control_sensor")) {
     controlSensor.textContent = payload.control_sensor || "primary";
   }
-  if (heatingState) {
+  if (heatingState && hasPayloadField(payload, "heating_state")) {
     heatingState.textContent = payload.heating_state;
   }
-  if (coolingState) {
+  if (coolingState && hasPayloadField(payload, "cooling_state")) {
     coolingState.textContent = payload.cooling_state;
   }
-  if (heatingStatusText) {
+  if (heatingStatusText && hasPayloadField(payload, "heating_state")) {
     heatingStatusText.textContent = payload.heating_state;
   }
-  if (coolingStatusText) {
+  if (coolingStatusText && hasPayloadField(payload, "cooling_state")) {
     coolingStatusText.textContent = payload.cooling_state;
   }
-  if (tempPrimary) {
+  if (tempPrimary && hasPayloadField(payload, "last_temp_c")) {
     tempPrimary.textContent = formatMetric(payload.last_temp_c, "temperature");
   }
-  if (tempTarget) {
+  if (tempTarget && hasPayloadField(payload, "last_target_temp_c")) {
     tempTarget.textContent = formatMetric(payload.last_target_temp_c, "temperature");
   }
-  if (configDesiredVersion) {
+  if (configDesiredVersion && hasPayloadField(payload, "fermentation_config")) {
     const desiredVersion = payload.fermentation_config?.desired_version;
     configDesiredVersion.textContent = `Desired version ${desiredVersion ?? 1}`;
   }
-  if (configLastApply) {
+  if (configLastApply && hasPayloadField(payload, "fermentation_config")) {
     const appliedResult = payload.fermentation_config?.last_applied_result;
     const appliedVersion = payload.fermentation_config?.last_applied_version;
     configLastApply.textContent = appliedResult
       ? `Last apply: ${appliedResult}${appliedVersion ? ` v${appliedVersion}` : ""}`
       : "Last apply: pending";
   }
-  if (configMessage) {
+  if (configMessage && hasPayloadField(payload, "fermentation_config")) {
     const message = payload.fermentation_config?.last_applied_message;
     configMessage.textContent = message || "";
     configMessage.hidden = !message;
   }
-  if (desiredVersionInput) {
+  if (desiredVersionInput && hasPayloadField(payload, "fermentation_config")) {
     const desiredVersion = payload.fermentation_config?.desired_version;
     desiredVersionInput.value = String((desiredVersion ?? 0) + 1);
   }

--- a/services/web/app/static/styles.css
+++ b/services/web/app/static/styles.css
@@ -280,6 +280,38 @@ body {
   color: var(--md-sys-color-on-surface-variant);
 }
 
+.fault-banner {
+  display: grid;
+  gap: 0.25rem;
+  margin: 1rem 0 1.15rem;
+  padding: 0.95rem 1rem;
+  border-radius: 20px;
+  border: 1px solid rgba(186, 26, 26, 0.18);
+  background: rgba(186, 26, 26, 0.06);
+  color: #8c0009;
+}
+
+.fault-banner[hidden] {
+  display: none;
+}
+
+.fault-banner.is-active {
+  box-shadow: 0 8px 22px rgba(186, 26, 26, 0.12);
+}
+
+.fault-banner__label {
+  font-size: 0.74rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-weight: 800;
+}
+
+.fault-banner strong {
+  font-size: 0.98rem;
+  line-height: 1.4;
+  letter-spacing: -0.01em;
+}
+
 .temperature-metrics {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -456,6 +488,38 @@ body {
   font-weight: 700;
   line-height: 1.25;
   overflow-wrap: anywhere;
+}
+
+.sensor-state {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  padding: 0.32rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.77rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.sensor-state.present {
+  background: rgba(47, 111, 79, 0.12);
+  color: #1f5f40;
+}
+
+.sensor-state.stale {
+  background: rgba(255, 185, 114, 0.22);
+  color: #7c4f00;
+}
+
+.sensor-state.invalid {
+  background: rgba(186, 26, 26, 0.12);
+  color: #8c0009;
+}
+
+.sensor-state.missing {
+  background: rgba(73, 69, 79, 0.08);
+  color: var(--md-sys-color-on-surface-variant);
 }
 
 .payload-box {

--- a/services/web/app/templates/device_detail.html
+++ b/services/web/app/templates/device_detail.html
@@ -150,11 +150,21 @@
         <h3>Controller status</h3>
       </div>
     </div>
+    <div
+      id="controller-fault-banner"
+      class="fault-banner {% if live_payload.has_fault %}is-active{% endif %}"
+      role="status"
+      aria-live="polite"
+      {% if not live_payload.has_fault %}hidden{% endif %}>
+      <span class="fault-banner__label">Controller fault</span>
+      <strong id="controller-fault-text">{{ live_payload.fault or "none" }}</strong>
+    </div>
     <dl class="spec-grid">
       <div><dt>MQTT</dt><dd id="mqtt-state">{{ "connected" if device.mqtt_connected else "disconnected" }}</dd></div>
       <div><dt>Last heartbeat</dt><dd id="last-heartbeat">{{ format_timestamp(device.last_heartbeat_at) }}</dd></div>
-      <div><dt>Controller</dt><dd id="controller-state">{{ device.last_payload.controller_state if device.last_payload and device.last_payload.controller_state else "unknown" }}</dd></div>
-      <div><dt>Controller reason</dt><dd id="controller-reason">{{ device.last_payload.controller_reason if device.last_payload and device.last_payload.controller_reason else "n/a" }}</dd></div>
+      <div><dt>Controller</dt><dd id="controller-state">{{ live_payload.controller_state or "unknown" }}</dd></div>
+      <div><dt>Controller reason</dt><dd id="controller-reason">{{ live_payload.fault or live_payload.controller_reason or "n/a" }}</dd></div>
+      <div><dt>Fault</dt><dd id="controller-fault-state">{{ live_payload.fault or "none" }}</dd></div>
       <div><dt>Heating</dt><dd id="heating-state">{{ device.heating_state or "unknown" }}</dd></div>
       <div><dt>Cooling</dt><dd id="cooling-state">{{ device.cooling_state or "unknown" }}</dd></div>
       <div><dt>RSSI</dt><dd>{{ device.last_rssi or "n/a" }}</dd></div>
@@ -170,12 +180,12 @@
       </div>
     </div>
     <dl class="spec-grid">
-      <div><dt>Beer probe</dt><dd id="beer-probe-status">{% if device.last_payload and device.last_payload.beer_probe_present %}{% if device.last_payload.beer_probe_valid %}present{% else %}invalid{% endif %}{% else %}missing{% endif %}</dd></div>
-      <div><dt>Beer ROM</dt><dd id="beer-probe-rom">{{ device.last_payload.beer_probe_rom if device.last_payload and device.last_payload.beer_probe_rom else "n/a" }}</dd></div>
-      <div><dt>Chamber probe</dt><dd id="chamber-probe-status">{% if device.last_payload and device.last_payload.chamber_probe_present %}{% if device.last_payload.chamber_probe_valid %}present{% else %}invalid{% endif %}{% else %}missing{% endif %}</dd></div>
-      <div><dt>Chamber ROM</dt><dd id="chamber-probe-rom">{{ device.last_payload.chamber_probe_rom if device.last_payload and device.last_payload.chamber_probe_rom else "n/a" }}</dd></div>
-      <div><dt>Secondary enabled</dt><dd id="secondary-enabled">{{ "yes" if device.last_payload and device.last_payload.secondary_sensor_enabled else "no" }}</dd></div>
-      <div><dt>Control sensor</dt><dd id="control-sensor">{{ device.last_payload.control_sensor if device.last_payload and device.last_payload.control_sensor else "primary" }}</dd></div>
+      <div><dt>Beer probe</dt><dd id="beer-probe-status" class="sensor-state {{ live_payload.beer_probe_status }}">{{ live_payload.beer_probe_status }}</dd></div>
+      <div><dt>Beer ROM</dt><dd id="beer-probe-rom">{{ live_payload.beer_probe_rom or "n/a" }}</dd></div>
+      <div><dt>Chamber probe</dt><dd id="chamber-probe-status" class="sensor-state {{ live_payload.chamber_probe_status }}">{{ live_payload.chamber_probe_status }}</dd></div>
+      <div><dt>Chamber ROM</dt><dd id="chamber-probe-rom">{{ live_payload.chamber_probe_rom or "n/a" }}</dd></div>
+      <div><dt>Secondary enabled</dt><dd id="secondary-enabled">{{ "yes" if live_payload.secondary_sensor_enabled else "no" }}</dd></div>
+      <div><dt>Control sensor</dt><dd id="control-sensor">{{ live_payload.control_sensor or "primary" }}</dd></div>
     </dl>
   </article>
 


### PR DESCRIPTION
## Summary

- add firmware stale/invalid sensor fault handling and fail-safe shutdown
- publish explicit MQTT fault and per-probe stale fields
- surface controller fault and degraded probe state in the web UI
- align the MQTT contract documentation with the implemented payloads and safety semantics

## Why

The DS18B20 path needed a real fault model so unsafe sensor states stop outputs locally, are visible to operators, and are documented consistently across firmware, web, and docs.

## Impact

- selected primary sensor faults now force both outputs off locally
- MQTT state and telemetry include `fault`, `beer_probe_stale`, and `chamber_probe_stale`
- the device detail page shows an explicit controller fault banner and clearer probe status
- docs now match the actual heartbeat, telemetry, and state payloads

## Validation

- `pio run` in `firmware/`
- manual firmware review of primary-sensor fail-safe and heating/cooling mutual exclusion
- `docker compose -f infra/compose.yaml build web`
- reviewer approval for firmware, web, and docs
- safety review approval for firmware and docs
