### PR TITLE
[codex] Fix firmware v2 network output handover

### DIFF
--- a/firmware_v2/src/kasa_output_driver.cpp
+++ b/firmware_v2/src/kasa_output_driver.cpp
@@ -3,6 +3,10 @@
 #include <ArduinoJson.h>
 #include <WiFi.h>
 
+namespace {
+constexpr uint32_t kKasaSocketTimeoutMs = 1500;
+}
+
 KasaOutputDriver::KasaOutputDriver(const OutputConfig &config, const String &role) : config_(config), role_(role) {}
 
 bool KasaOutputDriver::begin() {
@@ -12,6 +16,8 @@ bool KasaOutputDriver::begin() {
   status_.known = false;
   status_.on = false;
   updateDescription();
+  Serial.printf("[kasa:%s] init host=%s port=%u alias=%s poll_interval_s=%lu\n", role_.c_str(), config_.host.c_str(),
+                config_.port, config_.alias.c_str(), static_cast<unsigned long>(config_.poll_interval_s));
   if (WiFi.status() != WL_CONNECTED) {
     return true;
   }
@@ -22,6 +28,8 @@ bool KasaOutputDriver::setState(bool on) {
   if (WiFi.status() != WL_CONNECTED || config_.host.isEmpty()) {
     status_.known = false;
     updateDescription();
+    Serial.printf("[kasa:%s] refusing setState host=%s wifi=%d empty_host=%s\n", role_.c_str(), config_.host.c_str(),
+                  WiFi.status(), config_.host.isEmpty() ? "true" : "false");
     return false;
   }
   String response;
@@ -29,11 +37,30 @@ bool KasaOutputDriver::setState(bool on) {
   if (!sendCommand(command, response)) {
     status_.known = false;
     updateDescription();
+    Serial.printf("[kasa:%s] setState transport failed host=%s desired=%s\n", role_.c_str(), config_.host.c_str(),
+                  on ? "on" : "off");
     return false;
   }
-  status_.known = true;
-  status_.on = on;
-  updateDescription();
+  const int err_code = parseErrCode(response);
+  if (err_code != 0) {
+    status_.known = false;
+    updateDescription();
+    Serial.printf("[kasa:%s] setState err_code=%d host=%s desired=%s response=%s\n", role_.c_str(), err_code,
+                  config_.host.c_str(), on ? "on" : "off", response.c_str());
+    return false;
+  }
+  delay(150);
+  last_refresh_ms_ = 0;
+  if (!refresh()) {
+    Serial.printf("[kasa:%s] setState verify refresh failed host=%s desired=%s\n", role_.c_str(), config_.host.c_str(),
+                  on ? "on" : "off");
+    return false;
+  }
+  if (status_.on != on) {
+    Serial.printf("[kasa:%s] setState verify mismatch host=%s desired=%s actual=%s\n", role_.c_str(),
+                  config_.host.c_str(), on ? "on" : "off", status_.on ? "on" : "off");
+    return false;
+  }
   return true;
 }
 
@@ -52,6 +79,15 @@ bool KasaOutputDriver::refresh() {
   if (!sendCommand("{\"system\":{\"get_sysinfo\":{}}}", response)) {
     status_.known = false;
     updateDescription();
+    Serial.printf("[kasa:%s] refresh transport failed host=%s\n", role_.c_str(), config_.host.c_str());
+    return false;
+  }
+  const int err_code = parseErrCode(response);
+  if (err_code != 0) {
+    status_.known = false;
+    updateDescription();
+    Serial.printf("[kasa:%s] refresh err_code=%d host=%s response=%s\n", role_.c_str(), err_code, config_.host.c_str(),
+                  response.c_str());
     return false;
   }
 
@@ -59,6 +95,8 @@ bool KasaOutputDriver::refresh() {
   if (deserializeJson(doc, response)) {
     status_.known = false;
     updateDescription();
+    Serial.printf("[kasa:%s] refresh deserialize failed host=%s response=%s\n", role_.c_str(), config_.host.c_str(),
+                  response.c_str());
     return false;
   }
 
@@ -66,6 +104,8 @@ bool KasaOutputDriver::refresh() {
   if (!relay_state.is<int>()) {
     status_.known = false;
     updateDescription();
+    Serial.printf("[kasa:%s] refresh missing relay_state host=%s response=%s\n", role_.c_str(), config_.host.c_str(),
+                  response.c_str());
     return false;
   }
 
@@ -81,36 +121,72 @@ DriverStatus KasaOutputDriver::status() const {
 
 bool KasaOutputDriver::sendCommand(const String &command, String &response) {
   WiFiClient client;
+  client.setTimeout(kKasaSocketTimeoutMs);
   if (!client.connect(config_.host.c_str(), config_.port == 0 ? 9999 : config_.port)) {
+    Serial.printf("[kasa:%s] connect failed host=%s port=%u\n", role_.c_str(), config_.host.c_str(),
+                  config_.port == 0 ? 9999 : config_.port);
     return false;
   }
-  client.setTimeout(2500);
 
   const std::vector<uint8_t> payload = encryptPayload(command);
   if (client.write(payload.data(), payload.size()) != static_cast<int>(payload.size())) {
     client.stop();
+    Serial.printf("[kasa:%s] short write host=%s expected=%u\n", role_.c_str(), config_.host.c_str(),
+                  static_cast<unsigned>(payload.size()));
     return false;
   }
 
-  uint8_t buffer[1024];
-  size_t read_bytes = 0;
-  const uint32_t deadline = millis() + 2500;
-  while (millis() < deadline) {
-    while (client.available() && read_bytes < sizeof(buffer)) {
-      buffer[read_bytes++] = static_cast<uint8_t>(client.read());
-    }
-    if (!client.connected() && !client.available()) {
-      break;
-    }
-    delay(1);
+  uint8_t header[4];
+  if (client.readBytes(header, sizeof(header)) != sizeof(header)) {
+    client.stop();
+    Serial.printf("[kasa:%s] header read failed host=%s\n", role_.c_str(), config_.host.c_str());
+    return false;
+  }
+
+  const uint32_t response_length = (static_cast<uint32_t>(header[0]) << 24) | (static_cast<uint32_t>(header[1]) << 16) |
+                                   (static_cast<uint32_t>(header[2]) << 8) | static_cast<uint32_t>(header[3]);
+  std::vector<uint8_t> buffer(response_length);
+  if (response_length > 0 &&
+      client.readBytes(buffer.data(), response_length) != static_cast<int>(response_length)) {
+    client.stop();
+    Serial.printf("[kasa:%s] payload read failed host=%s expected=%lu\n", role_.c_str(), config_.host.c_str(),
+                  static_cast<unsigned long>(response_length));
+    return false;
   }
   client.stop();
 
-  if (read_bytes <= 4) {
-    return false;
+  response = decryptPayload(buffer.data(), buffer.size());
+  return true;
+}
+
+int KasaOutputDriver::parseErrCode(const String &response) {
+  int err_index = response.indexOf("\"err_code\"");
+  if (err_index < 0) {
+    return 0;
   }
-  response = decryptPayload(buffer + 4, read_bytes - 4);
-  return !response.isEmpty();
+
+  err_index = response.indexOf(':', err_index);
+  if (err_index < 0) {
+    return 0;
+  }
+
+  ++err_index;
+  while (err_index < response.length() && response[err_index] == ' ') {
+    ++err_index;
+  }
+
+  int end_index = err_index;
+  if (end_index < response.length() && response[end_index] == '-') {
+    ++end_index;
+  }
+  while (end_index < response.length() && isDigit(response[end_index])) {
+    ++end_index;
+  }
+
+  if (end_index == err_index) {
+    return 0;
+  }
+  return response.substring(err_index, end_index).toInt();
 }
 
 std::vector<uint8_t> KasaOutputDriver::encryptPayload(const String &payload) {

--- a/firmware_v2/src/kasa_output_driver.h
+++ b/firmware_v2/src/kasa_output_driver.h
@@ -16,6 +16,7 @@ class KasaOutputDriver : public OutputDriver {
 
  private:
   bool sendCommand(const String &command, String &response);
+  static int parseErrCode(const String &response);
   static std::vector<uint8_t> encryptPayload(const String &payload);
   static String decryptPayload(const uint8_t *buffer, size_t length);
   void updateDescription();

--- a/firmware_v2/src/main.cpp
+++ b/firmware_v2/src/main.cpp
@@ -123,7 +123,8 @@ bool shutOffForMutualExclusion(OutputDriver &output, const char *label) {
   if (output.setState(false)) {
     return true;
   }
-  Serial.printf("Refusing output handover because %s failed to turn off\n", label);
+  Serial.printf("Refusing output handover because %s failed to turn off (known=%s on=%s desc=%s)\n", label,
+                status.known ? "true" : "false", status.on ? "true" : "false", status.description.c_str());
   return false;
 }
 
@@ -372,8 +373,9 @@ void applyOutputCommand(const String &target, const String &state) {
   g_heating_output->refresh();
   g_cooling_output->refresh();
   g_state_dirty = true;
-  Serial.printf("Handled set_output target=%s state=%s changed=%s\n", target.c_str(), state.c_str(),
-                changed ? "true" : "false");
+  Serial.printf("Handled set_output target=%s state=%s changed=%s heating=%s cooling=%s\n", target.c_str(),
+                state.c_str(), changed ? "true" : "false", g_heating_output->status().description.c_str(),
+                g_cooling_output->status().description.c_str());
   publishStateIfConnected();
 }
 

--- a/firmware_v2/src/shelly_output_driver.cpp
+++ b/firmware_v2/src/shelly_output_driver.cpp
@@ -10,6 +10,8 @@ bool ShellyOutputDriver::begin() {
   status_.known = false;
   status_.on = false;
   updateDescription();
+  Serial.printf("[shelly:%s] init host=%s port=%u switch_id=%u https=%s\n", role_.c_str(), config_.host.c_str(),
+                config_.port == 0 ? 80 : config_.port, config_.switch_id, config_.https ? "true" : "false");
   if (WiFi.status() != WL_CONNECTED) {
     return true;
   }
@@ -20,6 +22,9 @@ bool ShellyOutputDriver::setState(bool on) {
   if (config_.https || WiFi.status() != WL_CONNECTED || config_.host.isEmpty()) {
     status_.known = false;
     updateDescription();
+    Serial.printf("[shelly:%s] refusing setState host=%s wifi=%d https=%s empty_host=%s\n", role_.c_str(),
+                  config_.host.c_str(), WiFi.status(), config_.https ? "true" : "false",
+                  config_.host.isEmpty() ? "true" : "false");
     return false;
   }
   String response;
@@ -27,11 +32,21 @@ bool ShellyOutputDriver::setState(bool on) {
   if (!performGet(path, response)) {
     status_.known = false;
     updateDescription();
+    Serial.printf("[shelly:%s] setState transport failed host=%s desired=%s\n", role_.c_str(), config_.host.c_str(),
+                  on ? "on" : "off");
     return false;
   }
-  status_.known = true;
-  status_.on = on;
-  updateDescription();
+  delay(100);
+  if (!refresh()) {
+    Serial.printf("[shelly:%s] setState verify refresh failed host=%s desired=%s response=%s\n", role_.c_str(),
+                  config_.host.c_str(), on ? "on" : "off", response.c_str());
+    return false;
+  }
+  if (status_.on != on) {
+    Serial.printf("[shelly:%s] setState verify mismatch host=%s desired=%s actual=%s response=%s\n", role_.c_str(),
+                  config_.host.c_str(), on ? "on" : "off", status_.on ? "on" : "off", response.c_str());
+    return false;
+  }
   return true;
 }
 
@@ -46,6 +61,7 @@ bool ShellyOutputDriver::refresh() {
   if (!performGet(path, response)) {
     status_.known = false;
     updateDescription();
+    Serial.printf("[shelly:%s] refresh transport failed host=%s\n", role_.c_str(), config_.host.c_str());
     return false;
   }
 
@@ -53,11 +69,17 @@ bool ShellyOutputDriver::refresh() {
   if (deserializeJson(doc, response)) {
     status_.known = false;
     updateDescription();
+    Serial.printf("[shelly:%s] refresh deserialize failed host=%s response=%s\n", role_.c_str(), config_.host.c_str(),
+                  response.c_str());
     return false;
   }
   status_.known = doc["output"].is<bool>();
   status_.on = doc["output"] | false;
   updateDescription();
+  if (!status_.known) {
+    Serial.printf("[shelly:%s] refresh missing output field host=%s response=%s\n", role_.c_str(), config_.host.c_str(),
+                  response.c_str());
+  }
   return status_.known;
 }
 
@@ -70,6 +92,7 @@ bool ShellyOutputDriver::performGet(const String &path, String &response) {
   HTTPClient http;
   const String url = "http://" + config_.host + ":" + String(config_.port == 0 ? 80 : config_.port) + path;
   if (!http.begin(client, url)) {
+    Serial.printf("[shelly:%s] http begin failed url=%s\n", role_.c_str(), url.c_str());
     return false;
   }
   http.setConnectTimeout(2500);
@@ -79,6 +102,7 @@ bool ShellyOutputDriver::performGet(const String &path, String &response) {
   }
   const int code = http.GET();
   if (code <= 0 || code >= 300) {
+    Serial.printf("[shelly:%s] http GET failed url=%s code=%d\n", role_.c_str(), url.c_str(), code);
     http.end();
     return false;
   }


### PR DESCRIPTION
## What changed
- restored stricter Kasa socket response handling in `firmware_v2` so relay commands read the full framed reply instead of relying on opportunistic socket reads
- verify Kasa and Shelly output state after `setState` calls and surface transport / parse / mismatch failures in serial logs
- include the current output descriptions in manual `set_output` handling and mutual-exclusion refusal logs to make failed handovers diagnosable on-device

## Why
Manual heating/cooling handover in `firmware_v2` had regressed for network-driven outputs. The firmware could end up treating the other relay as still on or unknown, then refuse the safety handover even though the underlying plug control path should have been allowed. The Kasa path in particular had been simplified compared with the earlier working implementation and was not reading the protocol response robustly.

## Impact
- Kasa and Shelly outputs should switch more reliably during manual handover
- if a relay still fails to switch, serial output now shows whether the failure was connect, HTTP, deserialize, protocol, or post-command verification
- mutual exclusion remains enforced

## Validation
- `C:\Users\ola\.platformio\penv\Scripts\pio.exe run` in `firmware_v2`
- `C:\Users\ola\.platformio\penv\Scripts\pio.exe run -t upload --upload-port COM4` in `firmware_v2`
- user confirmed Kasa/Shelly control was working after flashing on COM4
