### PR TITLE
[codex] Stabilize power-on boot sequence

### DIFF
--- a/firmware/src/App.cpp
+++ b/firmware/src/App.cpp
@@ -7,6 +7,7 @@ const uint32_t kHeartbeatLogIntervalMs = 5000;
 constexpr float kDefaultSetpointC = 20.0f;
 constexpr uint32_t kProfileRuntimePersistIntervalMs = 300000UL;
 constexpr uint32_t kSensorStaleAfterMs = 30000UL;
+constexpr uint32_t kWifiBootResetDelayMs = 200UL;
 
 bool isSensorStale(const SensorManager::Reading& reading, uint32_t nowMs) {
     return reading.updatedAtMs != 0 && static_cast<uint32_t>(nowMs - reading.updatedAtMs) > kSensorStaleAfterMs;
@@ -24,6 +25,10 @@ String sensorFaultReason(const char* sensorName, const SensorManager::Reading& r
 
 bool isManualOutputSelection(const String& value) {
     return value == "off" || value == "heating" || value == "cooling";
+}
+
+bool wifiHasUsableConnection() {
+    return WiFi.status() == WL_CONNECTED && WiFi.localIP() != IPAddress(0, 0, 0, 0);
 }
 }
 
@@ -116,6 +121,12 @@ void App::update() {
 
 void App::beginNormalMode() {
     provisioningMode_ = false;
+    wifiConnectStartedMs_ = 0;
+    WiFi.persistent(false);
+    WiFi.mode(WIFI_STA);
+    WiFi.disconnect(true, false);
+    delay(kWifiBootResetDelayMs);
+    Serial.println("[wifi] station reset complete");
     WiFi.mode(WIFI_STA);
     ensureWifiConnected();
     mqtt_.begin(config_);
@@ -839,14 +850,18 @@ void App::ensureWifiConnected() {
         return;
     }
 
-    if (WiFi.status() == WL_CONNECTED) {
+    if (wifiHasUsableConnection()) {
         wifiConnectStartedMs_ = 0;
         return;
     }
 
     if (wifiConnectStartedMs_ == 0) {
         wifiConnectStartedMs_ = millis();
-        Serial.printf("[wifi] connecting ssid=%s\r\n", config_.wifi.ssid.c_str());
+        Serial.printf(
+            "[wifi] connecting ssid=%s status=%d ip=%s\r\n",
+            config_.wifi.ssid.c_str(),
+            static_cast<int>(WiFi.status()),
+            WiFi.localIP().toString().c_str());
         WiFi.begin(config_.wifi.ssid.c_str(), config_.wifi.password.c_str());
         return;
     }

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -1,18 +1,120 @@
 #include <Arduino.h>
+#include <Preferences.h>
+#include <esp_system.h>
 
 #include "App.h"
 
 namespace {
 App app;
+constexpr uint32_t kPowerOnRestartMagic = 0xB007C0DEUL;
+constexpr uint32_t kPowerOnStabilizationDelayMs = 1500UL;
+RTC_DATA_ATTR uint32_t g_power_on_restart_magic = 0;
+constexpr char kBootTraceNamespace[] = "boottrace";
+constexpr char kBootTraceKey[] = "current";
+constexpr size_t kBootTraceMaxChars = 220;
+
+const char* resetReasonName(esp_reset_reason_t reason) {
+    switch (reason) {
+        case ESP_RST_UNKNOWN:
+            return "unknown";
+        case ESP_RST_POWERON:
+            return "power_on";
+        case ESP_RST_EXT:
+            return "external";
+        case ESP_RST_SW:
+            return "software";
+        case ESP_RST_PANIC:
+            return "panic";
+        case ESP_RST_INT_WDT:
+            return "interrupt_watchdog";
+        case ESP_RST_TASK_WDT:
+            return "task_watchdog";
+        case ESP_RST_WDT:
+            return "watchdog";
+        case ESP_RST_DEEPSLEEP:
+            return "deep_sleep";
+        case ESP_RST_BROWNOUT:
+            return "brownout";
+        case ESP_RST_SDIO:
+            return "sdio";
+        default:
+            return "other";
+    }
+}
+
+String readBootTrace() {
+    Preferences prefs;
+    if (!prefs.begin(kBootTraceNamespace, true)) {
+        return String();
+    }
+    const String trace = prefs.getString(kBootTraceKey, "");
+    prefs.end();
+    return trace;
+}
+
+void writeBootTrace(const String& trace) {
+    Preferences prefs;
+    if (!prefs.begin(kBootTraceNamespace, false)) {
+        return;
+    }
+    prefs.putString(kBootTraceKey, trace.substring(0, kBootTraceMaxChars));
+    prefs.end();
+}
+
+void appendBootTrace(const String& step) {
+    String trace = readBootTrace();
+    if (trace.isEmpty()) {
+        trace = step;
+    } else {
+        trace += " > " + step;
+    }
+    writeBootTrace(trace);
+}
 }
 
 void setup() {
     Serial.begin(115200);
     delay(250);
+
+    const esp_reset_reason_t resetReason = esp_reset_reason();
+    const String previousTrace = readBootTrace();
+    if (!previousTrace.isEmpty()) {
+        Serial.printf("[boot] previous_trace=%s\r\n", previousTrace.c_str());
+    }
+
+    writeBootTrace("reset=" + String(resetReasonName(resetReason)));
+    Serial.printf("[boot] reset_reason=%s\r\n", resetReasonName(resetReason));
+
+    const bool firstColdBootAttempt =
+        resetReason == ESP_RST_POWERON && g_power_on_restart_magic != kPowerOnRestartMagic;
+    if (firstColdBootAttempt) {
+        g_power_on_restart_magic = kPowerOnRestartMagic;
+        appendBootTrace("power_on_delay");
+        Serial.printf(
+            "[boot] power-on stabilization: waiting %lu ms then self-restarting\r\n",
+            static_cast<unsigned long>(kPowerOnStabilizationDelayMs));
+        delay(kPowerOnStabilizationDelayMs);
+        appendBootTrace("self_restart");
+        ESP.restart();
+    }
+
+    if (g_power_on_restart_magic == kPowerOnRestartMagic && resetReason == ESP_RST_SW) {
+        appendBootTrace("after_poweron_restart");
+        Serial.println("[boot] continuing after power-on stabilization restart");
+    }
+    g_power_on_restart_magic = 0;
+
+    appendBootTrace("app_begin");
     app.begin();
+    appendBootTrace("app_begin_ok");
 }
 
 void loop() {
+    static bool bootLoopRecorded = false;
+    if (!bootLoopRecorded) {
+        appendBootTrace("loop_entered");
+        bootLoopRecorded = true;
+    }
     app.update();
     delay(50);
 }


### PR DESCRIPTION
## Summary
- add a power-on boot stabilization restart so cold starts reproduce the extra reset that previously only happened during flash/serial workflows
- reset and reinitialize the Wi-Fi station state before normal startup, and require a real IP before treating Wi-Fi as connected
- persist short boot breadcrumbs in NVS so failed cold-start sequences can be inspected on the next successful boot

## Why
Cold starts were behaving differently from resets triggered by flashing or opening the serial monitor. The device often only recovered after an extra reset, which pointed to a power-on-specific timing or initialization issue.

## Impact
This makes cold-start behavior easier to diagnose and should reduce cases where the ESP only comes up cleanly after a manual or serial-triggered reset.

## Validation
- `C:\Users\ola\.platformio\penv\Scripts\pio.exe run`
- flashed to `COM4` with `C:\Users\ola\.platformio\penv\Scripts\pio.exe run -t upload`
- captured boot logs showing `POWERON_RESET`, the firmware-triggered stabilization restart, and subsequent successful app/network startup
