### PR TITLE
[codex] Add web-side device deletion

### DIFF
--- a/services/web/README.md
+++ b/services/web/README.md
@@ -12,6 +12,7 @@ Responsibilities:
 - telemetry/history storage
 - publish config JSON to MQTT
 - subscribe to state/telemetry topics
+- allow removing stale devices from the web registry when they are gone from MQTT
 
 Recommended first stack:
 
@@ -25,6 +26,7 @@ Current direction:
 - server-rendered FastAPI app with a modern dashboard UI
 - MQTT ingest for `availability`, `heartbeat`, and `state`
 - time-series storage in TimescaleDB for heartbeat and later telemetry history
+- manual device deletion from the dashboard only clears web-side stored state; a device that publishes MQTT again is recreated automatically
 
 Run locally with Docker Compose from:
 

--- a/services/web/app/main.py
+++ b/services/web/app/main.py
@@ -8,10 +8,10 @@ import re
 from xml.etree import ElementTree as ET
 
 from fastapi import FastAPI, File, HTTPException, Request, UploadFile
-from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from sqlalchemy import desc, select
+from sqlalchemy import delete, desc, select
 from sqlalchemy.orm import selectinload
 
 from .config import settings
@@ -19,6 +19,7 @@ from .db import SessionLocal, init_db
 from .models import (
     Device,
     DeviceFermentationConfig,
+    DeviceHeartbeat,
     DeviceOutputAssignment,
     DeviceTelemetry,
     DiscoveredRelay,
@@ -909,6 +910,17 @@ def _format_timestamp(value: datetime | None) -> str:
     return value.astimezone().strftime("%Y-%m-%d %H:%M:%S")
 
 
+def _delete_device_records(session, device: Device) -> None:
+    session.execute(delete(DeviceHeartbeat).where(DeviceHeartbeat.device_id == device.id))
+    session.execute(delete(DeviceTelemetry).where(DeviceTelemetry.device_id == device.id))
+    session.execute(
+        delete(DeviceFermentationConfig).where(DeviceFermentationConfig.device_id == device.id)
+    )
+    session.execute(delete(DeviceOutputAssignment).where(DeviceOutputAssignment.device_id == device.id))
+    session.execute(delete(DiscoveredRelay).where(DiscoveredRelay.source_device_id == device.id))
+    session.delete(device)
+
+
 OUTPUT_COMMAND_MAP = {
     "heating_on": {"command": "set_output", "target": "heating", "state": "on"},
     "heating_off": {"command": "set_output", "target": "heating", "state": "off"},
@@ -921,6 +933,8 @@ OUTPUT_COMMAND_MAP = {
 @app.get("/", response_class=HTMLResponse)
 def dashboard(request: Request):
     now = _utcnow()
+    deleted_device_id = request.query_params.get("device_deleted")
+    missing_device_id = request.query_params.get("device_missing")
     with SessionLocal() as session:
         devices = session.scalars(
             select(Device)
@@ -950,6 +964,8 @@ def dashboard(request: Request):
             "devices": devices,
             "telemetry_series": telemetry_series,
             "online_count": len([device for device in devices if device.display_status == "online"]),
+            "deleted_device_id": deleted_device_id,
+            "missing_device_id": missing_device_id,
             "page_title": "Fleet Overview",
             "format_temperature": _format_temperature,
             "format_timestamp": _format_timestamp,
@@ -1136,6 +1152,35 @@ def device_detail(request: Request, device_id: str):
             "page_title": f"{device.device_id} detail",
         },
     )
+
+
+@app.post("/devices/{device_id}/delete")
+def delete_device(request: Request, device_id: str):
+    with SessionLocal() as session:
+        device = session.scalar(select(Device).where(Device.device_id == device_id))
+        redirect_url = request.url_for("dashboard")
+        if device is None:
+            redirect_url = redirect_url.include_query_params(device_missing=device_id)
+            return RedirectResponse(str(redirect_url), status_code=303)
+
+        deleted_device_id = device.device_id
+        _delete_device_records(session, device)
+        session.commit()
+        redirect_url = redirect_url.include_query_params(device_deleted=deleted_device_id)
+        return RedirectResponse(str(redirect_url), status_code=303)
+
+
+@app.delete("/api/devices/{device_id}")
+def delete_device_api(device_id: str):
+    with SessionLocal() as session:
+        device = session.scalar(select(Device).where(Device.device_id == device_id))
+        if device is None:
+            return JSONResponse({"error": "Device not found"}, status_code=404)
+
+        deleted_device_id = device.device_id
+        _delete_device_records(session, device)
+        session.commit()
+        return JSONResponse({"status": "deleted", "device_id": deleted_device_id})
 
 
 @app.get("/api/devices/{device_id}/live")

--- a/services/web/app/static/styles.css
+++ b/services/web/app/static/styles.css
@@ -292,6 +292,30 @@ body {
   color: #8c0009;
 }
 
+.notice-banner {
+  margin: 0 0 1rem;
+  padding: 0.95rem 1rem;
+  border-radius: 20px;
+  border: 1px solid rgba(31, 39, 36, 0.08);
+  box-shadow: var(--elevation-1);
+}
+
+.notice-banner strong {
+  font-weight: 800;
+}
+
+.notice-banner--success {
+  background: rgba(47, 108, 96, 0.1);
+  border-color: rgba(47, 108, 96, 0.22);
+  color: #1f5f40;
+}
+
+.notice-banner--warning {
+  background: rgba(212, 106, 58, 0.12);
+  border-color: rgba(212, 106, 58, 0.2);
+  color: #8f4a24;
+}
+
 .fault-banner[hidden] {
   display: none;
 }
@@ -469,6 +493,17 @@ body {
 .device-card__footer {
   color: var(--md-sys-color-on-surface-variant);
   font-size: 0.88rem;
+}
+
+.device-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: end;
+  gap: 0.6rem;
+}
+
+.device-card__actions form {
+  margin: 0;
 }
 
 .inline-meta {
@@ -738,6 +773,16 @@ button:disabled {
   .control-status-grid,
   .spec-grid {
     grid-template-columns: 1fr;
+  }
+
+  .device-card__footer {
+    flex-direction: column;
+    align-items: start;
+  }
+
+  .device-card__actions {
+    width: 100%;
+    justify-content: start;
   }
 
   .line-chart {

--- a/services/web/app/templates/dashboard.html
+++ b/services/web/app/templates/dashboard.html
@@ -3,6 +3,16 @@
 {% block heading %}Fermentation Fleet{% endblock %}
 
 {% block content %}
+{% if deleted_device_id %}
+<section class="notice-banner notice-banner--success" aria-live="polite">
+  <strong>{{ deleted_device_id }}</strong> was removed from the web registry. If it publishes MQTT again, it will reappear automatically.
+</section>
+{% elif missing_device_id %}
+<section class="notice-banner notice-banner--warning" aria-live="polite">
+  <strong>{{ missing_device_id }}</strong> was already missing from the web registry.
+</section>
+{% endif %}
+
 <section class="hero-surface">
   <div>
     <p class="overline">Operations Surface</p>
@@ -79,7 +89,16 @@
 
     <footer class="device-card__footer">
       <span>Last heartbeat: {{ device.last_heartbeat_at or "never" }}</span>
-      <a href="/devices/{{ device.device_id }}">Open device</a>
+      <div class="device-card__actions">
+        <a href="/devices/{{ device.device_id }}">Open device</a>
+        <form
+          method="post"
+          action="/devices/{{ device.device_id }}/delete"
+          data-confirm-message="Delete {{ device.device_id }} from the web registry? It will come back automatically if it publishes MQTT again."
+          onsubmit="return confirm(this.dataset.confirmMessage);">
+          <button type="submit" class="danger-button">Delete</button>
+        </form>
+      </div>
     </footer>
   </article>
   {% else %}


### PR DESCRIPTION
## What changed
- added a backend delete flow for devices in the web registry
- removed related stored web data when a device is deleted, including heartbeat, telemetry, fermentation config, output routing, and discovered relays tied to that device
- added a delete action to each device card in the dashboard with confirmation and success/warning banners
- documented that deleting a device only clears web-side state and that MQTT publications recreate it automatically

## Why
Devices that are permanently gone from MQTT should not stay listed forever in the web UI. This adds a manual cleanup path without changing the MQTT-driven source of truth.

## Impact
- operators can remove stale ESP entries from the dashboard
- devices that publish on MQTT again will be recreated automatically
- no physical control-path behavior is changed

## Validation
- 
pm run check in services/web/frontend`n- manual diff review of the FastAPI/template/CSS changes
- Python syntax checks could not be run in this shell because neither python nor py is available