### PR TITLE
[codex] Add local profile runtime to firmware_v2

### DIFF
--- a/firmware_v2/README.md
+++ b/firmware_v2/README.md
@@ -11,10 +11,12 @@ Current scope in this rewrite:
 - local `system_config` persisted in NVS
 - recovery AP with onboarding page for Wi-Fi and MQTT bootstrap
 - cached `fermentation_config` persisted in NVS
+- local `manual`, `thermostat`, and `profile` fermentation modes
+- local profile runtime persisted in NVS for reboot recovery
 - DS18B20 beer/chamber probe handling on a shared OneWire bus
 - thermostat control with heating/cooling hysteresis, delays, and fault shutdown
 - pluggable output drivers for `gpio`, `shelly_http_rpc`, and `kasa_local`
-- MQTT availability, heartbeat, state, telemetry, and config apply handling
+- MQTT availability, heartbeat, state, telemetry, config apply, and profile control handling
 
 Current transport limits in `firmware_v2`:
 

--- a/firmware_v2/src/app_types.h
+++ b/firmware_v2/src/app_types.h
@@ -105,6 +105,43 @@ struct AlarmConfig {
   uint32_t sensor_stale_s = 30;
 };
 
+constexpr uint8_t kMaxProfileSteps = 10;
+
+struct ManualModeConfig {
+  String output = "off";
+};
+
+struct ProfileStepConfig {
+  String id;
+  String label;
+  float target_c = 20.0f;
+  uint32_t hold_duration_s = 0;
+  uint32_t ramp_duration_s = 0;
+  String advance_policy = "auto";
+};
+
+struct ProfileConfig {
+  String id;
+  uint8_t step_count = 0;
+  ProfileStepConfig steps[kMaxProfileSteps];
+};
+
+struct ProfileRuntimeState {
+  bool active = false;
+  String active_profile_id;
+  String active_step_id;
+  int active_step_index = -1;
+  String phase = "idle";
+  bool paused = false;
+  bool waiting_for_manual_release = false;
+  bool hold_timing_active = false;
+  float effective_target_c = 0.0f;
+  uint32_t step_started_ms = 0;
+  uint32_t step_hold_started_ms = 0;
+  uint32_t step_base_elapsed_s = 0;
+  uint32_t hold_base_elapsed_s = 0;
+};
+
 struct FermentationConfig {
   int schema_version = 2;
   uint32_t version = 0;
@@ -114,6 +151,8 @@ struct FermentationConfig {
   ThermostatConfig thermostat;
   SensorControlConfig sensors;
   AlarmConfig alarms;
+  ManualModeConfig manual;
+  ProfileConfig profile;
   bool valid = false;
 };
 

--- a/firmware_v2/src/config_store.cpp
+++ b/firmware_v2/src/config_store.cpp
@@ -6,6 +6,7 @@
 
 namespace {
 Preferences g_preferences;
+constexpr size_t kMaxStoredProfileRuntimeBytes = 768;
 
 String chipSuffix() {
   const uint64_t chip_id = ESP.getEfuseMac();
@@ -179,6 +180,7 @@ SystemConfig defaultSystemConfig() {
 FermentationConfig defaultFermentationConfig(const String &device_id) {
   FermentationConfig config;
   config.device_id = device_id;
+  config.manual.output = "off";
   config.valid = false;
   return config;
 }
@@ -436,7 +438,7 @@ String serializeSystemConfig(const SystemConfig &config) {
 }
 
 bool parseFermentationConfigJson(const String &payload, FermentationConfig &config, String &error) {
-  DynamicJsonDocument doc(3072);
+  DynamicJsonDocument doc(4096);
   DeserializationError parse_error = deserializeJson(doc, payload);
   if (parse_error) {
     error = "fermentation_config JSON parse failed";
@@ -469,6 +471,26 @@ bool parseFermentationConfigJson(const String &payload, FermentationConfig &conf
   config.alarms.deviation_c = alarms["deviation_c"] | config.alarms.deviation_c;
   config.alarms.sensor_stale_s = alarms["sensor_stale_s"] | config.alarms.sensor_stale_s;
 
+  JsonObjectConst manual = root["manual"].as<JsonObjectConst>();
+  config.manual.output = String(manual["output"] | config.manual.output);
+
+  JsonObjectConst profile = root["profile"].as<JsonObjectConst>();
+  config.profile.id = String(profile["id"] | config.profile.id);
+  config.profile.step_count = 0;
+  JsonArrayConst steps = profile["steps"].as<JsonArrayConst>();
+  for (JsonObjectConst step : steps) {
+    if (config.profile.step_count >= kMaxProfileSteps) {
+      break;
+    }
+    ProfileStepConfig &entry = config.profile.steps[config.profile.step_count++];
+    entry.id = String(step["id"] | entry.id);
+    entry.label = String(step["label"] | entry.label);
+    entry.target_c = step["target_c"] | entry.target_c;
+    entry.hold_duration_s = step["hold_duration_s"] | entry.hold_duration_s;
+    entry.ramp_duration_s = step["ramp_duration_s"] | entry.ramp_duration_s;
+    entry.advance_policy = String(step["advance_policy"] | entry.advance_policy);
+  }
+
   return true;
 }
 
@@ -486,8 +508,8 @@ bool validateFermentationConfig(FermentationConfig &config, const String &expect
     error = "fermentation_config device_id does not match this device";
     return false;
   }
-  if (config.mode != "thermostat") {
-    error = "profile mode is not implemented in firmware_v2 yet";
+  if (config.mode != "thermostat" && config.mode != "profile" && config.mode != "manual") {
+    error = "fermentation_config mode must be thermostat, profile, or manual";
     return false;
   }
   if (config.thermostat.hysteresis_c < 0.1f || config.thermostat.hysteresis_c > 5.0f) {
@@ -504,6 +526,45 @@ bool validateFermentationConfig(FermentationConfig &config, const String &expect
   }
   if (config.alarms.sensor_stale_s < 5) {
     config.alarms.sensor_stale_s = 5;
+  }
+  if (config.mode == "manual") {
+    if (config.manual.output != "off" && config.manual.output != "heating" && config.manual.output != "cooling") {
+      error = "manual.output must be off, heating, or cooling";
+      return false;
+    }
+  } else {
+    config.manual.output = "off";
+  }
+  if (config.mode == "profile") {
+    if (config.profile.id.isEmpty()) {
+      error = "profile.id is required when mode is profile";
+      return false;
+    }
+    if (config.profile.step_count == 0 || config.profile.step_count > kMaxProfileSteps) {
+      error = "profile.steps must include 1-10 steps";
+      return false;
+    }
+    for (uint8_t index = 0; index < config.profile.step_count; ++index) {
+      const ProfileStepConfig &step = config.profile.steps[index];
+      if (step.id.isEmpty()) {
+        error = "profile.steps[].id is required";
+        return false;
+      }
+      if (step.target_c < -20.0f || step.target_c > 50.0f) {
+        error = "profile.steps[].target_c must be between -20 and 50";
+        return false;
+      }
+      if (step.hold_duration_s > 3596400UL || step.ramp_duration_s > 3596400UL) {
+        error = "profile step durations must be <= 3596400 seconds";
+        return false;
+      }
+      if (step.advance_policy != "auto" && step.advance_policy != "manual_release") {
+        error = "profile.steps[].advance_policy must be auto or manual_release";
+        return false;
+      }
+    }
+  } else {
+    config.profile = ProfileConfig();
   }
   config.valid = true;
   return true;
@@ -534,7 +595,112 @@ String serializeFermentationConfig(const FermentationConfig &config) {
   alarms["deviation_c"] = config.alarms.deviation_c;
   alarms["sensor_stale_s"] = config.alarms.sensor_stale_s;
 
+  if (config.mode == "manual") {
+    JsonObject manual = doc.createNestedObject("manual");
+    manual["output"] = config.manual.output;
+  }
+
+  if (config.mode == "profile") {
+    JsonObject profile = doc.createNestedObject("profile");
+    profile["id"] = config.profile.id;
+    JsonArray steps = profile.createNestedArray("steps");
+    for (uint8_t index = 0; index < config.profile.step_count; ++index) {
+      const ProfileStepConfig &step = config.profile.steps[index];
+      JsonObject entry = steps.createNestedObject();
+      entry["id"] = step.id;
+      if (!step.label.isEmpty()) {
+        entry["label"] = step.label;
+      }
+      entry["target_c"] = step.target_c;
+      entry["hold_duration_s"] = step.hold_duration_s;
+      if (step.ramp_duration_s > 0) {
+        entry["ramp_duration_s"] = step.ramp_duration_s;
+      }
+      entry["advance_policy"] = step.advance_policy;
+    }
+  }
+
   String output;
   serializeJson(doc, output);
   return output;
+}
+
+bool ConfigStore::loadProfileRuntime(uint32_t expected_config_version, ProfileRuntimeState &runtime) {
+  if (!begin()) {
+    return false;
+  }
+  const String payload = g_preferences.getString("profile_rt", "");
+  if (payload.isEmpty()) {
+    return false;
+  }
+
+  DynamicJsonDocument doc(1024);
+  if (deserializeJson(doc, payload) != DeserializationError::Ok) {
+    return false;
+  }
+
+  if ((doc["config_version"] | 0U) != expected_config_version) {
+    return false;
+  }
+
+  ProfileRuntimeState loaded;
+  loaded.active = doc["active"] | false;
+  loaded.active_profile_id = String(doc["active_profile_id"] | "");
+  loaded.active_step_id = String(doc["active_step_id"] | "");
+  loaded.active_step_index = doc["active_step_index"] | -1;
+  loaded.phase = String(doc["phase"] | "idle");
+  loaded.paused = doc["paused"] | false;
+  loaded.waiting_for_manual_release = doc["waiting_for_manual_release"] | false;
+  loaded.hold_timing_active = doc["hold_timing_active"] | false;
+  loaded.effective_target_c = doc["effective_target_c"] | 0.0f;
+  loaded.step_base_elapsed_s = doc["step_elapsed_s"] | 0UL;
+  loaded.hold_base_elapsed_s = doc["hold_elapsed_s"] | 0UL;
+  runtime = loaded;
+  return loaded.active;
+}
+
+bool ConfigStore::saveProfileRuntime(uint32_t config_version, const ProfileRuntimeState &runtime, uint32_t now_ms) {
+  if (!begin()) {
+    return false;
+  }
+
+  DynamicJsonDocument doc(1024);
+  doc["config_version"] = config_version;
+  doc["active"] = runtime.active;
+  doc["active_profile_id"] = runtime.active_profile_id;
+  doc["active_step_id"] = runtime.active_step_id;
+  doc["active_step_index"] = runtime.active_step_index;
+  doc["phase"] = runtime.phase;
+  doc["paused"] = runtime.paused;
+  doc["waiting_for_manual_release"] = runtime.waiting_for_manual_release;
+  doc["hold_timing_active"] = runtime.hold_timing_active;
+  doc["effective_target_c"] = runtime.effective_target_c;
+
+  const bool timers_running = !runtime.paused && runtime.phase != "faulted" && runtime.phase != "completed";
+  uint32_t step_elapsed_s = runtime.step_base_elapsed_s;
+  if (timers_running && runtime.step_started_ms != 0 && static_cast<int32_t>(now_ms - runtime.step_started_ms) >= 0) {
+    step_elapsed_s += (now_ms - runtime.step_started_ms) / 1000UL;
+  }
+  doc["step_elapsed_s"] = step_elapsed_s;
+
+  uint32_t hold_elapsed_s = runtime.hold_base_elapsed_s;
+  if (timers_running && runtime.step_hold_started_ms != 0 &&
+      static_cast<int32_t>(now_ms - runtime.step_hold_started_ms) >= 0) {
+    hold_elapsed_s += (now_ms - runtime.step_hold_started_ms) / 1000UL;
+  }
+  doc["hold_elapsed_s"] = hold_elapsed_s;
+
+  String payload;
+  const size_t serialized_length = serializeJson(doc, payload);
+  if (serialized_length == 0 || serialized_length > kMaxStoredProfileRuntimeBytes) {
+    return false;
+  }
+  return g_preferences.putString("profile_rt", payload) > 0;
+}
+
+bool ConfigStore::clearProfileRuntime() {
+  if (!begin()) {
+    return false;
+  }
+  return g_preferences.remove("profile_rt");
 }

--- a/firmware_v2/src/config_store.h
+++ b/firmware_v2/src/config_store.h
@@ -11,6 +11,9 @@ class ConfigStore {
   bool saveSystemConfig(const SystemConfig &config);
   bool loadFermentationConfig(FermentationConfig &config);
   bool saveFermentationConfig(const FermentationConfig &config);
+  bool loadProfileRuntime(uint32_t expected_config_version, ProfileRuntimeState &runtime);
+  bool saveProfileRuntime(uint32_t config_version, const ProfileRuntimeState &runtime, uint32_t now_ms);
+  bool clearProfileRuntime();
 
  private:
   bool started_ = false;

--- a/firmware_v2/src/main.cpp
+++ b/firmware_v2/src/main.cpp
@@ -9,6 +9,7 @@
 
 #include "config_store.h"
 #include "output_factory.h"
+#include "profile_runtime.h"
 #include "provisioning_server.h"
 #include "sensor_manager.h"
 #include "thermostat_controller.h"
@@ -27,6 +28,7 @@ ConfigStore g_store;
 ProvisioningServer g_provisioning;
 SensorManager g_sensors;
 ThermostatController g_controller;
+ProfileRuntimeManager g_profile_runtime;
 SystemConfig g_system_config = defaultSystemConfig();
 FermentationConfig g_fermentation_config = defaultFermentationConfig(g_system_config.device_id);
 std::unique_ptr<OutputDriver> g_heating_output;
@@ -47,6 +49,9 @@ bool g_system_patch_pending_reboot = false;
 bool g_output_command_pending = false;
 String g_pending_output_target;
 String g_pending_output_state;
+bool g_profile_command_pending = false;
+String g_pending_profile_command;
+String g_pending_profile_step_id;
 
 void publishState();
 
@@ -60,6 +65,10 @@ String topicName(const char *suffix) {
 
 bool systemConfigChanged(const SystemConfig &current, const SystemConfig &updated) {
   return serializeSystemConfig(current) != serializeSystemConfig(updated);
+}
+
+bool fermentationConfigChanged(const FermentationConfig &current, const FermentationConfig &updated) {
+  return serializeFermentationConfig(current) != serializeFermentationConfig(updated);
 }
 
 time_t currentUnixTime() {
@@ -91,6 +100,26 @@ void rebuildOutputs() {
     g_cooling_output->begin();
   }
   g_state_dirty = true;
+}
+
+float publishedSetpointC() {
+  if (!g_fermentation_config.valid) {
+    return g_fermentation_config.thermostat.setpoint_c;
+  }
+  if (g_fermentation_config.mode == "profile" && g_profile_runtime.active()) {
+    return g_profile_runtime.activeStepTargetC(g_fermentation_config);
+  }
+  return g_fermentation_config.thermostat.setpoint_c;
+}
+
+bool controlSensorOperational(const SensorSnapshot &snapshot, const FermentationConfig &config) {
+  const ProbeReading &probe =
+      (config.sensors.control_sensor == "secondary" && config.sensors.secondary_enabled) ? snapshot.chamber : snapshot.beer;
+  return probe.present && probe.valid && !probe.stale;
+}
+
+void syncProfileRuntime() {
+  g_profile_runtime.syncToConfig(g_fermentation_config, g_store, millis());
 }
 
 void ensureOutputs() {
@@ -240,7 +269,7 @@ void publishTelemetry() {
     doc["temp_secondary_c"] = snapshot.chamber.adjusted_c;
   }
   if (g_fermentation_config.valid) {
-    doc["setpoint_c"] = g_fermentation_config.thermostat.setpoint_c;
+    doc["setpoint_c"] = publishedSetpointC();
   }
   doc["mode"] = g_fermentation_config.valid ? g_fermentation_config.mode : "thermostat";
   doc["controller_state"] = controller.controller_state;
@@ -259,6 +288,11 @@ void publishTelemetry() {
   doc["chamber_probe_rom"] = snapshot.chamber.rom;
   doc["heating"] = g_heating_output->status().on;
   doc["cooling"] = g_cooling_output->status().on;
+  if (g_fermentation_config.mode == "profile" && g_profile_runtime.active()) {
+    doc["profile_id"] = g_profile_runtime.state().active_profile_id;
+    doc["profile_step_id"] = g_profile_runtime.state().active_step_id;
+    doc["effective_target_c"] = g_profile_runtime.effectiveTargetC(g_fermentation_config);
+  }
   if (controller.fault.isEmpty()) {
     doc["fault"] = nullptr;
   } else {
@@ -281,7 +315,7 @@ void publishState() {
   doc["ui"] = "headless";
   doc["mode"] = g_fermentation_config.valid ? g_fermentation_config.mode : "thermostat";
   if (g_fermentation_config.valid) {
-    doc["setpoint_c"] = g_fermentation_config.thermostat.setpoint_c;
+    doc["setpoint_c"] = publishedSetpointC();
     doc["hysteresis_c"] = g_fermentation_config.thermostat.hysteresis_c;
     doc["cooling_delay_s"] = g_fermentation_config.thermostat.cooling_delay_s;
     doc["heating_delay_s"] = g_fermentation_config.thermostat.heating_delay_s;
@@ -310,6 +344,22 @@ void publishState() {
   doc["chamber_probe_valid"] = snapshot.chamber.valid;
   doc["chamber_probe_stale"] = snapshot.chamber.stale;
   doc["chamber_probe_rom"] = snapshot.chamber.rom;
+  if (g_fermentation_config.mode == "profile" && g_profile_runtime.active()) {
+    JsonObject runtime = doc.createNestedObject("profile_runtime");
+    runtime["active_profile_id"] = g_profile_runtime.state().active_profile_id;
+    runtime["active_step_id"] = g_profile_runtime.state().active_step_id;
+    runtime["active_step_index"] = g_profile_runtime.state().active_step_index;
+    runtime["phase"] = g_profile_runtime.state().phase;
+    runtime["step_started_at"] = g_profile_runtime.stepStartedAtSeconds(millis());
+    if (g_profile_runtime.hasStepHoldStarted()) {
+      runtime["step_hold_started_at"] = g_profile_runtime.stepHoldStartedAtSeconds(millis());
+    } else {
+      runtime["step_hold_started_at"] = nullptr;
+    }
+    runtime["effective_target_c"] = g_profile_runtime.effectiveTargetC(g_fermentation_config);
+    runtime["waiting_for_manual_release"] = g_profile_runtime.state().waiting_for_manual_release;
+    runtime["paused"] = g_profile_runtime.state().paused;
+  }
   if (controller.fault.isEmpty()) {
     doc["fault"] = nullptr;
   } else {
@@ -326,8 +376,13 @@ void handleFermentationConfigMessage(const String &payload) {
     publishConfigApplied("error", candidate.version, g_fermentation_config.version, error);
     return;
   }
+  if (!fermentationConfigChanged(g_fermentation_config, candidate)) {
+    publishConfigApplied("ok", candidate.version, g_fermentation_config.version, "");
+    return;
+  }
   g_fermentation_config = candidate;
   g_store.saveFermentationConfig(g_fermentation_config);
+  syncProfileRuntime();
   publishConfigApplied("ok", candidate.version, candidate.version, "");
   g_state_dirty = true;
 }
@@ -339,6 +394,25 @@ void applyOutputCommand(const String &target, const String &state) {
   const bool turn_off = state == "off";
   if (!turn_on && !turn_off) {
     Serial.printf("Ignoring set_output with invalid state=%s\n", state.c_str());
+    return;
+  }
+
+  if (g_fermentation_config.mode == "manual") {
+    String next_output = g_fermentation_config.manual.output;
+    if (target == "heating") {
+      next_output = turn_on ? "heating" : "off";
+    } else if (target == "cooling") {
+      next_output = turn_on ? "cooling" : "off";
+    } else if (target == "all" && turn_off) {
+      next_output = "off";
+    }
+
+    if (next_output != g_fermentation_config.manual.output &&
+        (next_output == "off" || next_output == "heating" || next_output == "cooling")) {
+      g_fermentation_config.manual.output = next_output;
+      g_store.saveFermentationConfig(g_fermentation_config);
+      g_state_dirty = true;
+    }
     return;
   }
 
@@ -396,6 +470,17 @@ void handleCommandMessage(const String &payload) {
     return;
   }
 
+  if (command == "profile_pause" || command == "profile_resume" || command == "profile_release_hold" ||
+      command == "profile_jump_to_step" || command == "profile_stop") {
+    JsonObjectConst args = doc["args"].as<JsonObjectConst>();
+    g_pending_profile_command = command;
+    g_pending_profile_step_id = String(args["step_id"] | "");
+    g_profile_command_pending = true;
+    Serial.printf("Queued profile command=%s step_id=%s\n", g_pending_profile_command.c_str(),
+                  g_pending_profile_step_id.c_str());
+    return;
+  }
+
   if (command == "discover_kasa") {
     Serial.println("Ignoring discover_kasa in firmware_v2: not implemented yet");
     return;
@@ -406,10 +491,19 @@ void handleCommandMessage(const String &payload) {
 
 void processPendingCommands() {
   if (!g_output_command_pending) {
+  } else {
+    g_output_command_pending = false;
+    applyOutputCommand(g_pending_output_target, g_pending_output_state);
+  }
+
+  if (!g_profile_command_pending) {
     return;
   }
-  g_output_command_pending = false;
-  applyOutputCommand(g_pending_output_target, g_pending_output_state);
+  g_profile_command_pending = false;
+  if (g_profile_runtime.handleCommand(g_fermentation_config, g_pending_profile_command, g_pending_profile_step_id, g_store,
+                                      millis())) {
+    g_state_dirty = true;
+  }
 }
 
 void handleSystemPatchMessage(const String &payload) {
@@ -534,6 +628,8 @@ void setupControllerData() {
   } else {
     g_fermentation_config = defaultFermentationConfig(g_system_config.device_id);
   }
+
+  syncProfileRuntime();
 }
 }  // namespace
 
@@ -589,7 +685,12 @@ void loop() {
   processPendingCommands();
   ensureOutputs();
   g_sensors.tick(g_system_config, g_fermentation_config, millis());
-  g_controller.evaluate(g_fermentation_config, g_sensors.snapshot(), millis());
+  const SensorSnapshot &snapshot = g_sensors.snapshot();
+  if (g_profile_runtime.update(g_fermentation_config, controlSensorOperational(snapshot, g_fermentation_config), g_store,
+                               millis())) {
+    g_state_dirty = true;
+  }
+  g_controller.evaluate(g_fermentation_config, g_profile_runtime.state(), snapshot, millis());
   g_controller.apply(*g_heating_output, *g_cooling_output, millis());
 
   if ((millis() - g_last_output_refresh_ms) > kOutputRefreshIntervalMs) {

--- a/firmware_v2/src/profile_runtime.cpp
+++ b/firmware_v2/src/profile_runtime.cpp
@@ -1,0 +1,360 @@
+#include "profile_runtime.h"
+
+namespace {
+constexpr uint32_t kProfileRuntimePersistIntervalMs = 300000UL;
+}
+
+bool ProfileRuntimeManager::syncToConfig(const FermentationConfig &config, ConfigStore &store, uint32_t now_ms) {
+  reset();
+
+  if (config.mode != "profile" || config.profile.step_count == 0) {
+    clearPersistedRuntime(store);
+    return false;
+  }
+
+  if (!restore(config, store, now_ms)) {
+    activateStep(config, 0, true, now_ms);
+  }
+
+  const bool changed = update(config, true, store, now_ms);
+  persist(store, config.version, now_ms, true);
+  return changed || state_.active;
+}
+
+bool ProfileRuntimeManager::update(const FermentationConfig &config, bool allow_progress, ConfigStore &store,
+                                   uint32_t now_ms) {
+  if (config.mode != "profile" || config.profile.step_count == 0 || !state_.active) {
+    return false;
+  }
+
+  if (!matchesConfig(config)) {
+    clearPersistedRuntime(store);
+    reset();
+    return true;
+  }
+
+  const ProfileStepConfig &step = config.profile.steps[state_.active_step_index];
+  const float previous_target =
+      state_.active_step_index == 0 ? step.target_c : config.profile.steps[state_.active_step_index - 1].target_c;
+  bool changed = false;
+
+  if (state_.phase == "completed") {
+    state_.effective_target_c = step.target_c;
+    persist(store, config.version, now_ms, false);
+    return false;
+  }
+
+  if (!allow_progress) {
+    if (state_.phase != "faulted") {
+      freezeTimers(now_ms);
+      state_.phase = "faulted";
+      changed = true;
+    }
+    persist(store, config.version, now_ms, changed);
+    return changed;
+  }
+
+  if (state_.phase == "faulted") {
+    resumeTimers(now_ms);
+  }
+
+  if (state_.paused) {
+    if (state_.phase != "paused") {
+      state_.phase = "paused";
+      changed = true;
+    }
+    persist(store, config.version, now_ms, changed);
+    return changed;
+  }
+
+  const uint32_t step_elapsed_s = currentStepElapsedSeconds(now_ms);
+  if (state_.active_step_index > 0 && step.ramp_duration_s > 0 && step_elapsed_s < step.ramp_duration_s) {
+    const float ramp_progress = static_cast<float>(step_elapsed_s) / static_cast<float>(step.ramp_duration_s);
+    if (state_.phase != "ramping") {
+      state_.phase = "ramping";
+      changed = true;
+    }
+    if (state_.waiting_for_manual_release) {
+      state_.waiting_for_manual_release = false;
+      changed = true;
+    }
+    if (state_.hold_timing_active) {
+      state_.hold_timing_active = false;
+      changed = true;
+    }
+    const float next_target = previous_target + ((step.target_c - previous_target) * ramp_progress);
+    state_.effective_target_c = next_target;
+    if (state_.step_hold_started_ms != 0 || state_.hold_base_elapsed_s != 0) {
+      state_.step_hold_started_ms = 0;
+      state_.hold_base_elapsed_s = 0;
+      changed = true;
+    }
+    persist(store, config.version, now_ms, false);
+    return changed;
+  }
+
+  state_.effective_target_c = step.target_c;
+  if (!state_.hold_timing_active) {
+    state_.hold_timing_active = true;
+    changed = true;
+  }
+  if (state_.step_hold_started_ms == 0) {
+    state_.step_hold_started_ms = now_ms;
+    state_.hold_base_elapsed_s = 0;
+    changed = true;
+  }
+
+  const bool waiting_for_manual_release = step.advance_policy == "manual_release";
+  const String next_phase = waiting_for_manual_release ? "waiting_manual_release" : "holding";
+  if (state_.phase != next_phase) {
+    state_.phase = next_phase;
+    changed = true;
+  }
+  if (state_.waiting_for_manual_release != waiting_for_manual_release) {
+    state_.waiting_for_manual_release = waiting_for_manual_release;
+    changed = true;
+  }
+
+  if (!waiting_for_manual_release) {
+    const uint32_t hold_elapsed_s = currentHoldElapsedSeconds(now_ms);
+    if (hold_elapsed_s >= step.hold_duration_s) {
+      if ((state_.active_step_index + 1) < config.profile.step_count) {
+        const bool advanced = activateStep(config, static_cast<uint8_t>(state_.active_step_index + 1), true, now_ms);
+        if (advanced) {
+          persist(store, config.version, now_ms, true);
+        }
+        return advanced;
+      }
+
+      if (state_.phase != "completed") {
+        state_.phase = "completed";
+        state_.waiting_for_manual_release = false;
+        changed = true;
+      }
+    }
+  }
+
+  persist(store, config.version, now_ms, changed);
+  return changed;
+}
+
+bool ProfileRuntimeManager::handleCommand(FermentationConfig &config, const String &command, const String &step_id,
+                                          ConfigStore &store, uint32_t now_ms) {
+  if (command == "profile_stop") {
+    if (config.mode != "profile") {
+      return false;
+    }
+    const FermentationConfig previous = config;
+    const float fallback_setpoint_c = effectiveTargetC(config);
+    config.mode = "thermostat";
+    config.thermostat.setpoint_c = fallback_setpoint_c;
+    if (!store.saveFermentationConfig(config)) {
+      config = previous;
+      return false;
+    }
+    clearPersistedRuntime(store);
+    reset();
+    return true;
+  }
+
+  if (config.mode != "profile" || config.profile.step_count == 0 || !state_.active) {
+    return false;
+  }
+
+  const ProfileRuntimeState previous = state_;
+  bool changed = false;
+
+  if (command == "profile_pause") {
+    if (!state_.paused && state_.phase != "completed") {
+      freezeTimers(now_ms);
+      state_.paused = true;
+      state_.phase = "paused";
+      changed = true;
+    }
+  } else if (command == "profile_resume") {
+    if (state_.paused) {
+      resumeTimers(now_ms);
+      state_.paused = false;
+      changed = true;
+    }
+  } else if (command == "profile_release_hold") {
+    if (state_.waiting_for_manual_release) {
+      const int next_step = state_.active_step_index + 1;
+      if (next_step >= config.profile.step_count) {
+        state_.waiting_for_manual_release = false;
+        state_.phase = "completed";
+        changed = true;
+      } else {
+        changed = activateStep(config, static_cast<uint8_t>(next_step), true, now_ms);
+      }
+    }
+  } else if (command == "profile_jump_to_step") {
+    for (uint8_t index = 0; index < config.profile.step_count; ++index) {
+      if (config.profile.steps[index].id == step_id) {
+        changed = activateStep(config, index, true, now_ms);
+        break;
+      }
+    }
+  }
+
+  if (!changed) {
+    return false;
+  }
+
+  update(config, true, store, now_ms);
+  if (!persist(store, config.version, now_ms, true)) {
+    state_ = previous;
+    return false;
+  }
+  return true;
+}
+
+const ProfileRuntimeState &ProfileRuntimeManager::state() const {
+  return state_;
+}
+
+bool ProfileRuntimeManager::active() const {
+  return state_.active;
+}
+
+float ProfileRuntimeManager::effectiveTargetC(const FermentationConfig &config) const {
+  if (config.mode == "profile" && state_.active) {
+    return state_.effective_target_c;
+  }
+  return config.thermostat.setpoint_c;
+}
+
+float ProfileRuntimeManager::activeStepTargetC(const FermentationConfig &config) const {
+  if (config.mode == "profile" && state_.active && matchesConfig(config)) {
+    return config.profile.steps[state_.active_step_index].target_c;
+  }
+  return config.thermostat.setpoint_c;
+}
+
+uint32_t ProfileRuntimeManager::stepStartedAtSeconds(uint32_t now_ms) const {
+  const uint32_t elapsed_s = currentStepElapsedSeconds(now_ms);
+  const uint32_t uptime_s = now_ms / 1000UL;
+  return elapsed_s > uptime_s ? 0 : uptime_s - elapsed_s;
+}
+
+bool ProfileRuntimeManager::hasStepHoldStarted() const {
+  return state_.step_hold_started_ms != 0 || state_.hold_base_elapsed_s != 0;
+}
+
+uint32_t ProfileRuntimeManager::stepHoldStartedAtSeconds(uint32_t now_ms) const {
+  const uint32_t elapsed_s = currentHoldElapsedSeconds(now_ms);
+  const uint32_t uptime_s = now_ms / 1000UL;
+  return elapsed_s > uptime_s ? 0 : uptime_s - elapsed_s;
+}
+
+bool ProfileRuntimeManager::activateStep(const FermentationConfig &config, uint8_t step_index, bool fresh_step,
+                                         uint32_t now_ms) {
+  if (step_index >= config.profile.step_count) {
+    return false;
+  }
+
+  const ProfileStepConfig &step = config.profile.steps[step_index];
+  const float previous_target = step_index == 0 ? step.target_c : config.profile.steps[step_index - 1].target_c;
+  const bool has_ramp = step_index > 0 && step.ramp_duration_s > 0;
+
+  state_.active = true;
+  state_.active_profile_id = config.profile.id;
+  state_.active_step_id = step.id;
+  state_.active_step_index = step_index;
+  state_.paused = false;
+  state_.waiting_for_manual_release = false;
+  state_.hold_timing_active = !has_ramp;
+  state_.phase = has_ramp ? "ramping" : (step.advance_policy == "manual_release" ? "waiting_manual_release" : "holding");
+  state_.effective_target_c = has_ramp ? previous_target : step.target_c;
+
+  if (fresh_step) {
+    state_.step_started_ms = now_ms;
+    state_.step_hold_started_ms = has_ramp ? 0 : now_ms;
+    state_.step_base_elapsed_s = 0;
+    state_.hold_base_elapsed_s = 0;
+  }
+
+  return true;
+}
+
+bool ProfileRuntimeManager::restore(const FermentationConfig &config, ConfigStore &store, uint32_t now_ms) {
+  ProfileRuntimeState restored;
+  if (!store.loadProfileRuntime(config.version, restored)) {
+    return false;
+  }
+
+  state_ = restored;
+  if (!matchesConfig(config)) {
+    reset();
+    clearPersistedRuntime(store);
+    return false;
+  }
+
+  state_.step_started_ms = now_ms;
+  state_.step_hold_started_ms = state_.hold_timing_active ? now_ms : 0;
+  return true;
+}
+
+bool ProfileRuntimeManager::persist(ConfigStore &store, uint32_t config_version, uint32_t now_ms, bool force) {
+  if (!state_.active) {
+    return false;
+  }
+  if (!force && (now_ms - last_persist_ms_) < kProfileRuntimePersistIntervalMs) {
+    return false;
+  }
+  if (!store.saveProfileRuntime(config_version, state_, now_ms)) {
+    return false;
+  }
+  last_persist_ms_ = now_ms;
+  return true;
+}
+
+void ProfileRuntimeManager::reset() {
+  state_ = ProfileRuntimeState();
+  last_persist_ms_ = 0;
+}
+
+void ProfileRuntimeManager::clearPersistedRuntime(ConfigStore &store) {
+  store.clearProfileRuntime();
+  last_persist_ms_ = 0;
+}
+
+uint32_t ProfileRuntimeManager::currentStepElapsedSeconds(uint32_t now_ms) const {
+  uint32_t elapsed_s = state_.step_base_elapsed_s;
+  if (!state_.paused && state_.phase != "faulted" && state_.phase != "completed" && state_.step_started_ms != 0 &&
+      static_cast<int32_t>(now_ms - state_.step_started_ms) >= 0) {
+    elapsed_s += (now_ms - state_.step_started_ms) / 1000UL;
+  }
+  return elapsed_s;
+}
+
+uint32_t ProfileRuntimeManager::currentHoldElapsedSeconds(uint32_t now_ms) const {
+  uint32_t elapsed_s = state_.hold_base_elapsed_s;
+  if (!state_.paused && state_.phase != "faulted" && state_.phase != "completed" && state_.step_hold_started_ms != 0 &&
+      static_cast<int32_t>(now_ms - state_.step_hold_started_ms) >= 0) {
+    elapsed_s += (now_ms - state_.step_hold_started_ms) / 1000UL;
+  }
+  return elapsed_s;
+}
+
+void ProfileRuntimeManager::freezeTimers(uint32_t now_ms) {
+  state_.step_base_elapsed_s = currentStepElapsedSeconds(now_ms);
+  state_.step_started_ms = now_ms;
+  state_.hold_base_elapsed_s = currentHoldElapsedSeconds(now_ms);
+  if (state_.step_hold_started_ms != 0) {
+    state_.step_hold_started_ms = now_ms;
+  }
+}
+
+void ProfileRuntimeManager::resumeTimers(uint32_t now_ms) {
+  state_.step_started_ms = now_ms;
+  if (state_.step_hold_started_ms != 0 || state_.hold_base_elapsed_s > 0) {
+    state_.step_hold_started_ms = now_ms;
+  }
+}
+
+bool ProfileRuntimeManager::matchesConfig(const FermentationConfig &config) const {
+  return state_.active && state_.active_profile_id == config.profile.id && state_.active_step_index >= 0 &&
+         state_.active_step_index < config.profile.step_count &&
+         config.profile.steps[state_.active_step_index].id == state_.active_step_id;
+}

--- a/firmware_v2/src/profile_runtime.h
+++ b/firmware_v2/src/profile_runtime.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "app_types.h"
+#include "config_store.h"
+
+class ProfileRuntimeManager {
+ public:
+  bool syncToConfig(const FermentationConfig &config, ConfigStore &store, uint32_t now_ms);
+  bool update(const FermentationConfig &config, bool allow_progress, ConfigStore &store, uint32_t now_ms);
+  bool handleCommand(FermentationConfig &config, const String &command, const String &step_id, ConfigStore &store,
+                     uint32_t now_ms);
+
+  const ProfileRuntimeState &state() const;
+  bool active() const;
+  float effectiveTargetC(const FermentationConfig &config) const;
+  float activeStepTargetC(const FermentationConfig &config) const;
+  uint32_t stepStartedAtSeconds(uint32_t now_ms) const;
+  bool hasStepHoldStarted() const;
+  uint32_t stepHoldStartedAtSeconds(uint32_t now_ms) const;
+
+ private:
+  bool activateStep(const FermentationConfig &config, uint8_t step_index, bool fresh_step, uint32_t now_ms);
+  bool restore(const FermentationConfig &config, ConfigStore &store, uint32_t now_ms);
+  bool persist(ConfigStore &store, uint32_t config_version, uint32_t now_ms, bool force);
+  void reset();
+  void clearPersistedRuntime(ConfigStore &store);
+  uint32_t currentStepElapsedSeconds(uint32_t now_ms) const;
+  uint32_t currentHoldElapsedSeconds(uint32_t now_ms) const;
+  void freezeTimers(uint32_t now_ms);
+  void resumeTimers(uint32_t now_ms);
+  bool matchesConfig(const FermentationConfig &config) const;
+
+  ProfileRuntimeState state_;
+  uint32_t last_persist_ms_ = 0;
+};

--- a/firmware_v2/src/thermostat_controller.cpp
+++ b/firmware_v2/src/thermostat_controller.cpp
@@ -7,10 +7,18 @@ const ProbeReading *selectControlProbe(const FermentationConfig &config, const S
   }
   return &sensors.beer;
 }
+
+float effectiveSetpointC(const FermentationConfig &config, const ProfileRuntimeState &profile_runtime) {
+  if (config.mode == "profile" && profile_runtime.active) {
+    return profile_runtime.effective_target_c;
+  }
+  return config.thermostat.setpoint_c;
+}
 }  // namespace
 
-const ControllerState &ThermostatController::evaluate(const FermentationConfig &config, const SensorSnapshot &sensors,
-                                                      uint32_t now_ms) {
+const ControllerState &ThermostatController::evaluate(const FermentationConfig &config,
+                                                      const ProfileRuntimeState &profile_runtime,
+                                                      const SensorSnapshot &sensors, uint32_t now_ms) {
   (void)now_ms;
   state_ = ControllerState();
 
@@ -18,9 +26,28 @@ const ControllerState &ThermostatController::evaluate(const FermentationConfig &
     state_.controller_reason = "no active config";
     return state_;
   }
-  if (config.mode != "thermostat") {
+  if (config.mode == "manual") {
+    state_.automatic_control_active = false;
+    state_.controller_reason = "manual output selection";
+    if (config.manual.output == "heating") {
+      state_.heating_command = true;
+      state_.controller_state = "heating";
+    } else if (config.manual.output == "cooling") {
+      state_.cooling_command = true;
+      state_.controller_state = "cooling";
+    }
+    return state_;
+  }
+  if (config.mode != "thermostat" && config.mode != "profile") {
     state_.fault = "unsupported mode";
-    state_.controller_reason = "profile mode not implemented";
+    state_.controller_reason = "unsupported mode";
+    state_.controller_state = "fault";
+    return state_;
+  }
+  if (config.mode == "profile" && !profile_runtime.active) {
+    state_.fault = "profile runtime inactive";
+    state_.controller_reason = "profile runtime inactive";
+    state_.controller_state = "fault";
     return state_;
   }
 
@@ -46,7 +73,7 @@ const ControllerState &ThermostatController::evaluate(const FermentationConfig &
     return state_;
   }
 
-  const float setpoint = config.thermostat.setpoint_c;
+  const float setpoint = effectiveSetpointC(config, profile_runtime);
   const float hysteresis = config.thermostat.hysteresis_c;
   const float control_temp = control_probe->adjusted_c;
   bool heating_demand = control_temp < (setpoint - hysteresis);

--- a/firmware_v2/src/thermostat_controller.h
+++ b/firmware_v2/src/thermostat_controller.h
@@ -14,7 +14,8 @@ struct ControllerState {
 
 class ThermostatController {
  public:
-  const ControllerState &evaluate(const FermentationConfig &config, const SensorSnapshot &sensors, uint32_t now_ms);
+  const ControllerState &evaluate(const FermentationConfig &config, const ProfileRuntimeState &profile_runtime,
+                                  const SensorSnapshot &sensors, uint32_t now_ms);
   void apply(OutputDriver &heating, OutputDriver &cooling, uint32_t now_ms);
   const ControllerState &state() const;
 


### PR DESCRIPTION
## What changed
- add native `manual` and `profile` mode support to `firmware_v2`'s fermentation config model
- persist and restore `profile_runtime` in NVS on the v2 firmware path
- run profile step progression locally inside `firmware_v2`, including ramp, hold, pause/resume, manual release, jump-to-step, and stop handling
- publish `state.profile_runtime` and related profile telemetry fields from `firmware_v2`
- document the expanded `firmware_v2` scope in the v2 README

## Why
Issue #38 calls out that `firmware_v2` lost local profile runtime handling after the rollback. That left the controller able to cache thermostat config, but not actually execute fermentation profiles locally or recover profile progress after reboot. The goal here is to restore that capability on the v2 codebase without reusing the old firmware structure.

## Impact
- `firmware_v2` can now execute retained profiles locally after config delivery
- active profile progress survives reboot via persisted runtime state
- the physical control path remains local and does not depend on MQTT for ongoing profile execution
- manual mode output intent is now modeled directly in the v2 config path

## Validation
- `pio run` in `firmware_v2`
- flashed current branch build to ESP32 on `COM4`

## Notes
- the worktree still had unrelated pre-existing changes in generated web assets, and they were intentionally left out of this PR
- flashing this branch onto a device with legacy v1-style NVS config does not migrate old network settings automatically; new settings saved through the v2 recovery AP use the new v2 storage format
